### PR TITLE
[FEAT] 프로필 편집 뷰 - 저장 로직 구현 (+ 컴포넌트 UI 수정)

### DIFF
--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -303,6 +303,8 @@ enum StringLiterals {
     
     enum Profile {
         
+        static let profilePageTitle = "프로필"
+        
         static let profileEditPageTitle = "프로필 편집"
         
         static let profileEditButton = "프로필 수정하기"

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -317,6 +317,8 @@ enum StringLiterals {
         
         static let myVerifiedArea = "나의 인증 동네"
         
+        static let neccessaryStarWithSpace = " *"
+        
         static let nickname = "닉네임"
         
         static let birthDate = "생년월일"

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserInfoModel {
+struct UserInfoModel: Equatable {
     
     var profileImageURL: String
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
@@ -21,6 +21,18 @@ struct UserInfoModel {
     
 }
 
+struct UserInfoEditModel {
+    
+    var profileImageURL: String
+    
+    var nickname: String
+    
+    var birthDate: String?
+    
+    var verifiedAreaList: [VerifiedAreaModel]
+    
+}
+
 
 struct VerifiedAreaModel: Equatable {
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileBoxComponent.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileBoxComponent.swift
@@ -19,13 +19,16 @@ class ProfileBoxComponent: BaseView {
     
     private var contentView = UIView()
     
+    private var secondaryContentView = UIView()
+    
     
     // MARK: - LifeCycles
     
     override func setHierarchy() {
         self.addSubviews(
             titleStackView,
-            contentView
+            contentView,
+            secondaryContentView
         )
         
         titleStackView.addArrangedSubviews(
@@ -48,6 +51,10 @@ class ProfileBoxComponent: BaseView {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(titleStackView.snp.bottom).offset(10)
             $0.bottom.equalToSuperview().offset(-16)
+        }
+        
+        secondaryContentView.snp.makeConstraints {
+            $0.edges.equalTo(contentView)
         }
     }
     
@@ -89,6 +96,23 @@ extension ProfileBoxComponent {
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+    
+    func setSecondaryContentView(to contentView: UIView) {
+        self.secondaryContentView.subviews.forEach {
+            $0.removeFromSuperview()
+        }
+        
+        self.secondaryContentView.addSubview(contentView)
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func switchContentView(toSecondary: Bool) {
+        contentView.isHidden = toSecondary
+        secondaryContentView.isHidden = !toSecondary
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditView.swift
@@ -62,7 +62,13 @@ class ProfileEditView: BaseView {
     override func setStyle() {
         super.setStyle()
         
-        nicknameTitleLabel.setLabel(text: StringLiterals.Profile.nickname, style: .h8)
+        nicknameTitleLabel.setPartialText(
+            fullText: StringLiterals.Profile.nickname + StringLiterals.Profile.neccessaryStarWithSpace,
+            textStyles: [
+                (text: StringLiterals.Profile.nickname, style: .h8, color: .acWhite),
+                (text: StringLiterals.Profile.neccessaryStarWithSpace, style: .h8, color: .org1)
+            ]
+        )
         
         nicknameTextField.do {
             $0.setPlaceholder(as: StringLiterals.Profile.nicknamePlaceholder)
@@ -76,7 +82,13 @@ class ProfileEditView: BaseView {
             $0.keyboardType = .numberPad
         }
         
-        verifiedAreaTitleLabel.setLabel(text: StringLiterals.Profile.verifiedArea, style: .h8)
+        verifiedAreaTitleLabel.setPartialText(
+            fullText: StringLiterals.Profile.verifiedArea + StringLiterals.Profile.neccessaryStarWithSpace,
+            textStyles: [
+                (text: StringLiterals.Profile.verifiedArea, style: .h8, color: .acWhite),
+                (text: StringLiterals.Profile.neccessaryStarWithSpace, style: .h8, color: .org1)
+            ]
+        )
         
         verifiedAreaStackView.do {
             $0.axis = .horizontal

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditView.swift
@@ -97,15 +97,16 @@ class ProfileEditView: BaseView {
         
         saveButton.do {
             var config = UIButton.Configuration.filled()
-            config.attributedTitle = AttributedString(StringLiterals.Profile.save.ACStyle(.h7))
+            config.attributedTitle = AttributedString(StringLiterals.Profile.save.ACStyle(.h7, .gray5))
             config.baseBackgroundColor = .gray7
-            config.baseForegroundColor = .gray5
             $0.configuration = config
         }
         
         saveButton.configurationUpdateHandler = {
             guard var config = $0.configuration else { return }
-            config.baseForegroundColor = $0.isEnabled ? .acWhite : .gray5
+            config.attributedTitle = AttributedString(
+                StringLiterals.Profile.save.ACStyle(.h7, $0.isEnabled ? .acWhite : .gray5)
+            )
             $0.configuration = config
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -153,13 +153,13 @@ private extension ProfileEditViewController {
             if areas.isEmpty {
                 profileEditView.hideVerifiedAreaAddButton(false)
                 isVerifiedAreaAvailable = false
-                checkSaveAvailability()
             } else {
                 profileEditView.hideVerifiedAreaAddButton(true)
                 profileEditView.addVerifiedArea(areas)
                 isVerifiedAreaAvailable = true
-                checkSaveAvailability()
             }
+            
+            checkSaveAvailability()
         }
         
         localVerificationVM.localArea.bind { [weak self] area in
@@ -219,6 +219,7 @@ private extension ProfileEditViewController {
             validityTestDebouncer.call { [weak self] in
                 guard let self = self else { return }
                 checkNicknameValidity()
+                checkSaveAvailability()
             }
         }
         
@@ -337,10 +338,6 @@ extension ProfileEditViewController: UITextFieldDelegate {
         }
         print("❌ Invaild Textfield")
         return false
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        checkSaveAvailability()
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -109,6 +109,12 @@ class ProfileEditViewController: BaseNavViewController {
             action: #selector(deleteVerifiedArea),
             for: .touchUpInside
         )
+        
+        profileEditView.saveButton.addTarget(
+            self,
+            action: #selector(tappedSaveButton),
+            for: .touchUpInside
+        )
     }
     
 }
@@ -244,6 +250,7 @@ private extension ProfileEditViewController {
     
     @objc
     func tappedProfileImageEditButton() {
+        // TODO: 수정
         print("profileImageEditButtonTapped")
     }
     
@@ -261,6 +268,25 @@ private extension ProfileEditViewController {
         // TODO: 특정 인덱스만 날리도록 수정 (Sprint3)
         viewModel.verifiedAreaListEditing.value?.removeAll()
         profileEditView.removeVerifiedArea()
+    }
+    
+    @objc
+    func tappedSaveButton() {
+        guard let nickname: String = profileEditView.nicknameTextField.text,
+              let verifiedAreaList = viewModel.verifiedAreaListEditing.value else { return }
+        
+        viewModel.updateUserInfo(
+            newUserInfo: UserInfoEditModel(
+                profileImageURL: "newProfileImageURL", // TODO: 수정
+                nickname: nickname,
+                birthDate: profileEditView.birthDateTextField.text,
+                verifiedAreaList: verifiedAreaList
+            )
+        )
+        
+        // TODO: 서버 Post
+        
+        self.navigationController?.popViewController(animated: true)
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -200,6 +200,10 @@ private extension ProfileEditViewController {
             guard let self = self,
                   let text = text else { return }
             
+            // NOTE: 닉네임 필드 값이 변하면 일단 막기 (유효성검사를 0.5초 뒤에 하기 때문에)
+            isNicknameAvailable = false
+            checkSaveAvailability()
+            
             profileEditView.nicknameTextField.hideClearButton(isHidden: text.isEmpty)
             
             // NOTE: 텍스트 변하면 유효성 메시지 숨김, 텍스트필드 UI 변경

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -132,14 +132,15 @@ private extension ProfileEditViewController {
     
     func bindData() {
         // NOTE: 기본 데이터 바인딩
+        guard let userInfo = viewModel.userInfo.value else { return }
         profileEditView.do {
-            $0.setProfileImage(viewModel.userInfo.profileImageURL)
-            $0.nicknameTextField.text = viewModel.userInfo.nickname
+            $0.setProfileImage(userInfo.profileImageURL)
+            $0.nicknameTextField.text = userInfo.nickname
             $0.setNicknameLengthLabel(
-                countPhoneme(text: viewModel.userInfo.nickname),
+                countPhoneme(text: userInfo.nickname),
                 viewModel.maxNicknameLength
                 )
-            $0.birthDateTextField.text = viewModel.userInfo.birthDate
+            $0.birthDateTextField.text = userInfo.birthDate
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -63,8 +63,11 @@ class ProfileEditViewController: BaseNavViewController {
         super.viewWillAppear(animated)
         
         self.tabBarController?.tabBar.isHidden = true
+        
+        // NOTE: 생일 필드는 옵셔널이기 때문에, 데이터가 텍스트필드에 바인딩된 후 clearButton configure를 해줘야 합니다
         let birthDateTF = profileEditView.birthDateTextField
         birthDateTF.hideClearButton(isHidden: (birthDateTF.text ?? "").isEmpty)
+        
         checkSaveAvailability()
     }
     
@@ -167,6 +170,7 @@ private extension ProfileEditViewController {
                   let area = area else { return }
             
             var newAreas = viewModel.verifiedAreaListEditing.value ?? []
+            // TODO: VerifiedArea id 수정
             newAreas.append(VerifiedAreaModel(id: 1, name: area))
             viewModel.verifiedAreaListEditing.value = newAreas
         }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -226,6 +226,14 @@ private extension ProfileEditViewController {
             let bindedText = text ?? ""
             
             profileEditView.birthDateTextField.hideClearButton(isHidden: bindedText.isEmpty)
+            
+            if bindedText.isEmpty {
+                profileEditView.setBirthdateValidMessage(.none)
+                profileEditView.birthDateTextField.changeBorderColor(toRed: false)
+                isBirthDateAvailable = true
+            }
+            
+            checkSaveAvailability()
         }
     }
     
@@ -388,12 +396,8 @@ private extension ProfileEditViewController {
         }
         
         // NOTE: 8자리 제한
-        // TODO: 길이 0인 경우 OK인지 기획 확인
-        if newRawString.count == 0 {
-            profileEditView.setBirthdateValidMessage(.none)
-            profileEditView.birthDateTextField.changeBorderColor(toRed: false)
-            isBirthDateAvailable = true
-        } else if newRawString.count < 8 {
+        // NOTE: 길이 0인 경우 ObservableBinding에서 .none처리
+        if newRawString.count < 8 {
             profileEditView.setBirthdateValidMessage(.invalidDate)
             profileEditView.birthDateTextField.changeBorderColor(toRed: true)
             isBirthDateAvailable = false

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -22,9 +22,21 @@ class ProfileEditViewController: BaseNavViewController {
     private var keyboardWillShowObserver: NSObjectProtocol?
     private var keyboardWillHideObserver: NSObjectProtocol?
     
-    private var isNicknameAvailable: Bool = true
-    private var isBirthDateAvailable: Bool = true
-    private var isVerifiedAreaAvailable: Bool = true
+    private var isNicknameAvailable: Bool = true {
+        didSet {
+            checkSaveAvailability()
+        }
+    }
+    private var isBirthDateAvailable: Bool = true {
+        didSet {
+            checkSaveAvailability()
+        }
+    }
+    private var isVerifiedAreaAvailable: Bool = true {
+        didSet {
+            checkSaveAvailability()
+        }
+    }
     
     
     // MARK: - Life Cycle
@@ -161,8 +173,6 @@ private extension ProfileEditViewController {
                 profileEditView.addVerifiedArea(areas)
                 isVerifiedAreaAvailable = true
             }
-            
-            checkSaveAvailability()
         }
         
         localVerificationVM.localArea.bind { [weak self] area in
@@ -204,9 +214,8 @@ private extension ProfileEditViewController {
             guard let self = self,
                   let text = text else { return }
             
-            // NOTE: 닉네임 필드 값이 변하면 일단 막기 (유효성검사를 0.5초 뒤에 하기 때문에)
+            // NOTE: 닉네임 필드 값이 변하면 일단 저장 막기 (유효성검사를 0.5초 뒤에 하기 때문에)
             isNicknameAvailable = false
-            checkSaveAvailability()
             
             profileEditView.nicknameTextField.hideClearButton(isHidden: text.isEmpty)
             
@@ -223,7 +232,6 @@ private extension ProfileEditViewController {
             validityTestDebouncer.call { [weak self] in
                 guard let self = self else { return }
                 checkNicknameValidity()
-                checkSaveAvailability()
             }
         }
         
@@ -241,8 +249,6 @@ private extension ProfileEditViewController {
                 profileEditView.birthDateTextField.changeBorderColor(toRed: false)
                 isBirthDateAvailable = true
             }
-            
-            checkSaveAvailability()
         }
     }
     
@@ -385,7 +391,7 @@ private extension ProfileEditViewController {
     // MARK: - 생년월일
     
     func birthDateTextFieldChange(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let currentString = textField.text else { print("date = nil"); return true }
+        guard let currentString = textField.text else { return true }
         let newString = (currentString as NSString).replacingCharacters(in: range, with: string)
         let newRawString = (newString.replacingOccurrences(of: ".", with: ""))
         

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -85,10 +85,19 @@ final class ProfileView: BaseView {
             icon: .icLocalAconG20
         )
         
-        verifiedAreaBox.setStyle(
-            title: StringLiterals.Profile.myVerifiedArea,
-            icon: .icHometownG20
-        )
+        verifiedAreaBox.do {
+            $0.setStyle(
+                title: StringLiterals.Profile.myVerifiedArea,
+                icon: .icHometownG20
+            )
+            
+            let notVerifiedLabel = UILabel()
+            notVerifiedLabel.setLabel(text: StringLiterals.Profile.notVerified,
+                           style: .t2,
+                           color: .gray5)
+            $0.setSecondaryContentView(to: notVerifiedLabel)
+        }
+        
         
         disableAutoLoginButton.do { // TODO: 삭제
             $0.setAttributedTitle(text: "자동로그인 해제", style: .b4)
@@ -199,13 +208,17 @@ extension ProfileView {
         acornCountBox.setContentView(to: acornCountabel)
     }
     
-    func setVerifiedAreaBox(onLogin: Bool, areaName: String) {
+    func setVerifiedAreaBox(areaName: String) {
         let label = UILabel()
-        label.setLabel(text: onLogin ? areaName : StringLiterals.Profile.notVerified,
+        label.setLabel(text: areaName,
                        style: .t2,
-                       color: onLogin ? .org1 : .gray5)
+                       color: .org1)
         
         verifiedAreaBox.setContentView(to: label)
+    }
+    
+    func setVerifiedAreaBox(onLoginSuccess: Bool) {
+        verifiedAreaBox.switchContentView(toSecondary: !onLoginSuccess)
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -98,7 +98,6 @@ final class ProfileView: BaseView {
             $0.setSecondaryContentView(to: notVerifiedLabel)
         }
         
-        
         disableAutoLoginButton.do { // TODO: 삭제
             $0.setAttributedTitle(text: "자동로그인 해제", style: .b4)
             $0.layer.borderColor = UIColor.acWhite.cgColor

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -82,20 +82,25 @@ private extension ProfileViewController {
                   let onLoginSuccess = onLoginSuccess
             else { return }
             
-            // TODO: 인증동네 추후 여러개로 수정(Sprint3)
-            let firstAreaName: String = self.viewModel.userInfo.verifiedAreaList.first?.name ?? "impossible"
-            
             self.profileView.do {
                 $0.needLoginButton.isHidden = onLoginSuccess
-                $0.setVerifiedAreaBox(onLogin: onLoginSuccess,
-                                      areaName: firstAreaName)
+                $0.setVerifiedAreaBox(onLoginSuccess: onLoginSuccess)
             }
         }
         
-        profileView.do {
-            $0.setProfileImage(viewModel.userInfo.profileImageURL)
-            $0.setNicknameLabel(viewModel.userInfo.nickname)
-            $0.setAcornCountBox(viewModel.userInfo.possessingAcorns)
+        viewModel.userInfo.bind { [weak self] userInfo in
+            guard let self = self,
+                  let userInfo = userInfo else { return }
+            
+            // TODO: 인증동네 추후 여러개로 수정(Sprint3)
+            let firstAreaName: String = self.viewModel.userInfo.value?.verifiedAreaList.first?.name ?? "impossible"
+            
+            profileView.do {
+                $0.setProfileImage(userInfo.profileImageURL)
+                $0.setNicknameLabel(userInfo.nickname)
+                $0.setAcornCountBox(userInfo.possessingAcorns)
+                $0.setVerifiedAreaBox(areaName: firstAreaName)
+            }
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -48,7 +48,7 @@ class ProfileViewController: BaseNavViewController {
     override func setStyle() {
         super.setStyle()
         
-        self.setCenterTitleLabelStyle(title: "프로필", fontStyle: .h5)
+        self.setCenterTitleLabelStyle(title: StringLiterals.Profile.profilePageTitle, fontStyle: .h5)
     }
     
     private func addTarget() {

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -32,4 +32,14 @@ class ProfileViewModel {
         verifiedAreaListEditing.value = userInfo.verifiedAreaList
     }
     
+    
+    // MARK: - Methods
+    
+    func updateUserInfo(newUserInfo: UserInfoEditModel) {
+        userInfo.profileImageURL = newUserInfo.profileImageURL
+        userInfo.nickname = newUserInfo.nickname
+        userInfo.birthDate = newUserInfo.birthDate
+        userInfo.verifiedAreaList = newUserInfo.verifiedAreaList
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -15,12 +15,14 @@ class ProfileViewModel {
     
     var verifiedAreaListEditing: ObservablePattern<[VerifiedAreaModel]> = ObservablePattern(nil)
     
-    var userInfo = UserInfoModel(
-        profileImageURL: "",
-        nickname: "김유림",
-        birthDate: nil,
-        verifiedAreaList: [VerifiedAreaModel(id: 1, name: "유림동")],
-        possessingAcorns: 0
+    var userInfo: ObservablePattern<UserInfoModel> = ObservablePattern(
+        UserInfoModel(
+            profileImageURL: "",
+            nickname: "김유림",
+            birthDate: nil,
+            verifiedAreaList: [VerifiedAreaModel(id: 1, name: "유림동")],
+            possessingAcorns: 0
+        )
     )
     
     let maxNicknameLength: Int = 16
@@ -29,17 +31,17 @@ class ProfileViewModel {
     // MARK: - Initializer
     
     init() {
-        verifiedAreaListEditing.value = userInfo.verifiedAreaList
+        verifiedAreaListEditing.value = userInfo.value?.verifiedAreaList
     }
     
     
     // MARK: - Methods
     
     func updateUserInfo(newUserInfo: UserInfoEditModel) {
-        userInfo.profileImageURL = newUserInfo.profileImageURL
-        userInfo.nickname = newUserInfo.nickname
-        userInfo.birthDate = newUserInfo.birthDate
-        userInfo.verifiedAreaList = newUserInfo.verifiedAreaList
+        userInfo.value?.profileImageURL = newUserInfo.profileImageURL
+        userInfo.value?.nickname = newUserInfo.nickname
+        userInfo.value?.birthDate = newUserInfo.birthDate
+        userInfo.value?.verifiedAreaList = newUserInfo.verifiedAreaList
     }
     
 }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #12 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
**저장 로직을 구현했습니다.**
- 텍스트필드, 인증동네 값이 변경될 때마다 저장 버튼이 활성화되어야하는지 체크합니다.
- 저장 버튼을 누르면 뷰모델에 userInfo 값을 변경하고 popVC 합니다.

**ProfileView에서 인증동네 라벨 수정**
이전 코드에서는 1개의 라벨을 가지고 로그인 여부에 따라 "00동" 또는 "미인증"으로 스위치되도록 했는데,
저장 로직을 구현하다보니 코드가 더럽더라구요
그래서 secondaryContentView(=미인증)를 만들어두고, 로그인 상태에 따라 isHidden 시키는 방향으로 수정했습니다.

----
+) 추가 (2025.02.13 19:00)
ProfileEditView - 닉네임, 인증동네 라벨에 주황별 추가


## 📸 스크린샷

https://github.com/user-attachments/assets/7f4b6c40-8c3a-40f2-a19b-662335588d96  

<img src ="https://github.com/user-attachments/assets/0e8ae203-0fcc-4017-843d-0f8b9464d80c" width="250"> +) 추가 (2025.02.13 19:00)


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #12
