### PR TITLE
[FEAT] 토큰 재발급 API 연결 (#31)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		74B25C302D2FEFE1008BDCB7 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 74B25C2F2D2FEFE1008BDCB7 /* Release.xcconfig */; };
 		74B25C322D2FF022008BDCB7 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 74B25C312D2FF022008BDCB7 /* Shared.xcconfig */; };
 		74B817F32D3A7C8000C1D516 /* SpotReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B817F22D3A7C7900C1D516 /* SpotReviewViewModel.swift */; };
+		74BBADF62D611B6B003AB16C /* PostReissueResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BBADF52D611B63003AB16C /* PostReissueResponse.swift */; };
+		74BBADFC2D6130E6003AB16C /* PostReissueRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BBADFB2D6130DF003AB16C /* PostReissueRequest.swift */; };
 		74BF91FA2D38164400B923E3 /* SpotDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF91F92D38163F00B923E3 /* SpotDetailView.swift */; };
 		74BF91FD2D381FF800B923E3 /* SpotDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF91FC2D381FF400B923E3 /* SpotDetailModel.swift */; };
 		74BF92022D385D8700B923E3 /* MenuCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF92012D385D8100B923E3 /* MenuCollectionViewCell.swift */; };
@@ -367,6 +369,8 @@
 		74B25C2F2D2FEFE1008BDCB7 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		74B25C312D2FF022008BDCB7 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		74B817F22D3A7C7900C1D516 /* SpotReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotReviewViewModel.swift; sourceTree = "<group>"; };
+		74BBADF52D611B63003AB16C /* PostReissueResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReissueResponse.swift; sourceTree = "<group>"; };
+		74BBADFB2D6130DF003AB16C /* PostReissueRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReissueRequest.swift; sourceTree = "<group>"; };
 		74BF91F92D38163F00B923E3 /* SpotDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotDetailView.swift; sourceTree = "<group>"; };
 		74BF91FC2D381FF400B923E3 /* SpotDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotDetailModel.swift; sourceTree = "<group>"; };
 		74BF92012D385D8100B923E3 /* MenuCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -773,6 +777,8 @@
 		745B19AA2D4001B400BDBDA4 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				74BBADFB2D6130DF003AB16C /* PostReissueRequest.swift */,
+				74BBADF52D611B63003AB16C /* PostReissueResponse.swift */,
 				745B19AD2D40029A00BDBDA4 /* PostLoginResponse.swift */,
 				745B19AB2D40021700BDBDA4 /* PostLoginRequest.swift */,
 			);
@@ -1612,6 +1618,7 @@
 				746261792D3EA8DF00A4E84F /* UploadTargetType.swift in Sources */,
 				741A07572D3558FE00778219 /* ReviewFinishedView.swift in Sources */,
 				1547A88E2D35B13700E96616 /* FilterTagButton.swift in Sources */,
+				74BBADF62D611B6B003AB16C /* PostReissueResponse.swift in Sources */,
 				748D6F7E2D2BCD72007690B4 /* StringLiterals.swift in Sources */,
 				747F4FBD2D3D9477003DECBF /* SplashViewController.swift in Sources */,
 				D6D0F51B2D36BABB00326F17 /* FavoriteSpotRankCollectionView.swift in Sources */,
@@ -1625,6 +1632,7 @@
 				D6D0F51D2D36BAD900326F17 /* OnboardingViewModel.swift in Sources */,
 				74CDCE542D310A1C00E3A21A /* ACFontStyleType.swift in Sources */,
 				15CD25892D42099100320006 /* WideTouchView.swift in Sources */,
+				74BBADFC2D6130E6003AB16C /* PostReissueRequest.swift in Sources */,
 				15A3F7A12D38C71900577E16 /* PriorityLowEmptyView.swift in Sources */,
 				74B817F32D3A7C8000C1D516 /* SpotReviewViewModel.swift in Sources */,
 				748D6F802D2BCD94007690B4 /* ObservablePattern.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -13,6 +13,8 @@ enum StringLiterals {
         
         static let accessToken = "accessToken"
         
+        static let refreshToken = "refreshToken"
+        
     }
     
     enum Login {

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -5,16 +5,66 @@
 //  Created by 이수민 on 1/23/25.
 //
 
-import Foundation
+import UIKit
 
 final class AuthManager {
-    
     static let shared = AuthManager()
     private init() {}
     
     var hasToken: Bool {
         get {
             UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) != nil
+        }
+    }
+
+    func handleTokenRefresh() async throws -> Bool {
+        let refreshToken = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.refreshToken) ?? ""
+        return try await withCheckedThrowingContinuation { continuation in
+            ACService.shared.authService.postReissue(PostReissueRequest(refreshToken: refreshToken)) { response in
+                switch response {
+                case .success(let data):
+                    print("❄️ token refreshed success")
+                    UserDefaults.standard.set(data.accessToken, forKey: StringLiterals.UserDefaults.accessToken)
+                    UserDefaults.standard.set(data.refreshToken, forKey: StringLiterals.UserDefaults.refreshToken)
+                    continuation.resume(returning: true)
+                default:
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+}
+
+
+// MARK: - Servicable
+
+protocol Serviceable: AnyObject { }
+
+extension Serviceable {
+    
+    func handleReissue(retryAction: @escaping () -> Void) {
+        Task {
+            do {
+                let success = try await AuthManager.shared.handleTokenRefresh()
+                DispatchQueue.main.async {
+                    if success {
+                        print("❄️ 기존 서버통신 다시 성공")
+                        retryAction()
+                    } else {
+                        self.navigateToSplash()
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.navigateToSplash()
+                }
+            }
+        }
+    }
+    
+    private func navigateToSplash() {
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = SplashViewController()
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Network/Auth/AuthService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Auth/AuthService.swift
@@ -13,6 +13,9 @@ protocol AuthServiceProtocol {
     
     func postLogin(_ requestBody: PostLoginRequest,
                    completion: @escaping (NetworkResult<PostLoginResponse>) -> Void)
+    
+    func postReissue(_ requestBody: PostReissueRequest,
+                     completion: @escaping (NetworkResult<PostReissueResponse>) -> Void)
 
     
 }
@@ -24,6 +27,18 @@ final class AuthService: BaseService<AuthTargetType>, AuthServiceProtocol {
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<PostLoginResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: PostLoginResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+    
+    func postReissue(_ requestBody: PostReissueRequest, completion: @escaping (NetworkResult<PostReissueResponse>) -> Void) {
+        self.provider.request(.postReissue(requestBody)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<PostReissueResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: PostReissueResponse.self)
                 completion(networkResult)
             case .failure(let errorResponse):
                 print(errorResponse)

--- a/ACON-iOS/ACON-iOS/Network/Auth/AuthTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Auth/AuthTargetType.swift
@@ -13,13 +13,15 @@ enum AuthTargetType {
 
     case postLogin(_ requestBody: PostLoginRequest)
     
+    case postReissue(_ requestBody: PostReissueRequest)
+    
 }
 
 extension AuthTargetType: TargetType {
 
     var method: Moya.Method {
         switch self {
-        case .postLogin:
+        case .postLogin, .postReissue:
             return .post
         }
     }
@@ -28,6 +30,8 @@ extension AuthTargetType: TargetType {
         switch self {
         case .postLogin:
             return utilPath + "auth/login"
+        case .postReissue:
+            return utilPath + "auth/reissue"
         }
     }
     
@@ -35,13 +39,15 @@ extension AuthTargetType: TargetType {
         switch self {
         case .postLogin(let requestBody):
             return .requestJSONEncodable(requestBody)
+        case .postReissue(let requestBody):
+            return .requestJSONEncodable(requestBody)
         }
     }
     
     var headers: [String : String]? {
         var headers = HeaderType.basicHeader
         switch self {
-        case .postLogin:
+        case .postLogin, .postReissue:
             headers = HeaderType.basicHeader
         }
         return headers

--- a/ACON-iOS/ACON-iOS/Network/Auth/DTO/PostReissueRequest.swift
+++ b/ACON-iOS/ACON-iOS/Network/Auth/DTO/PostReissueRequest.swift
@@ -1,0 +1,14 @@
+//
+//  PostReissueRequest.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 2/16/25.
+//
+
+import Foundation
+
+struct PostReissueRequest: Codable {
+    
+    let refreshToken: String
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/Auth/DTO/PostReissueResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/Auth/DTO/PostReissueResponse.swift
@@ -1,0 +1,16 @@
+//
+//  PostReissueResponse.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 2/16/25.
+//
+
+import Foundation
+
+struct PostReissueResponse: Codable {
+    
+    let accessToken: String
+    
+    let refreshToken: String
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/Base/BaseService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/BaseService.swift
@@ -62,6 +62,8 @@ class BaseService<T: TargetType> {
         switch statusCode {
         case 200:
             return decodeData(data: data, type: type)
+        case 401:
+            return .reIssueJWT
         case 400..<500:
             return decodeErrorData(data: data)
         case 500:

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import Foundation
 
-class LocalVerificationViewModel {
+class LocalVerificationViewModel: Serviceable {
     
     var flowType: LocalVerificationFlowType
     
@@ -42,6 +42,10 @@ class LocalVerificationViewModel {
             case .success(let data):
                 self?.localArea.value = data.area
                 self?.onSuccessPostLocalArea.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postLocalArea()
+                }
             default:
                 print("Failed To Post")
                 self?.onSuccessPostLocalArea.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -11,7 +11,7 @@ import GoogleSignIn
 import GoogleSignInSwift
 import AuthenticationServices
 
-class LoginViewModel {
+class LoginViewModel: Serviceable {
     
     var onSuccessLogin: ObservablePattern<Bool> = ObservablePattern(nil)
     
@@ -57,6 +57,10 @@ class LoginViewModel {
                 UserDefaults.standard.set(data.accessToken, forKey: StringLiterals.UserDefaults.accessToken)
                 UserDefaults.standard.set(data.refreshToken, forKey: StringLiterals.UserDefaults.refreshToken)
                 self?.onSuccessLogin.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postLogin(socialType: socialType, idToken: idToken)
+                }
             default:
                 print("VM - Failed To postLogin")
                 self?.onSuccessLogin.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -50,12 +50,12 @@ class LoginViewModel {
         }
     }
     
-    // TODO: - 앱잼 기간 내에는 우선 accessToken만 받아옴 - 나중에 refreshToken 받아오기
     func postLogin(socialType: String, idToken: String) {
         ACService.shared.authService.postLogin(PostLoginRequest(socialType: socialType, idToken: idToken)){ [weak self] response in
             switch response {
             case .success(let data):
                 UserDefaults.standard.set(data.accessToken, forKey: StringLiterals.UserDefaults.accessToken)
+                UserDefaults.standard.set(data.refreshToken, forKey: StringLiterals.UserDefaults.refreshToken)
                 self?.onSuccessLogin.value = true
             default:
                 print("VM - Failed To postLogin")

--- a/ACON-iOS/ACON-iOS/Presentation/OnBoarding/ViewModel/OnboardingViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/OnBoarding/ViewModel/OnboardingViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class OnboardingViewModel {
+final class OnboardingViewModel: Serviceable {
     
     var dislike: ObservablePattern<[String]> = ObservablePattern([])
     
@@ -45,6 +45,10 @@ final class OnboardingViewModel {
             case .success(_):
                 print("Onboarding Success")
                 self.postOnboardingResult.value = true
+            case .reIssueJWT:
+                self.handleReissue { [weak self] in
+                    self?.postOnboarding()
+                }
             default:
                 print("Onboarding Failed")
                 self.postOnboardingResult.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import CoreLocation
 
-class SpotDetailViewModel {
+class SpotDetailViewModel: Serviceable {
     
     let spotID: Int64
     
@@ -54,6 +54,10 @@ extension SpotDetailViewModel {
                                                          longitude: data.longitude)
                 self?.spotDetail.value = spotDetailData
                 self?.onSuccessGetSpotDetail.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getSpotDetail()
+                }
             default:
                 print("VM - Failed To getSpotDetail")
                 self?.onSuccessGetSpotDetail.value = false
@@ -74,6 +78,10 @@ extension SpotDetailViewModel {
                     }
                     self?.spotMenu.value = spotMenuData
                     self?.onSuccessGetSpotMenu.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getSpotMenu()
+                }
             default:
                 print("VM - Failed To getSpotMenu")
                 self?.onSuccessGetSpotMenu.value = false
@@ -88,6 +96,10 @@ extension SpotDetailViewModel {
             switch response {
             case .success(let data):
                 self?.onSuccessPostGuidedSpotRequest.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postGuidedSpot()
+                }
             default:
                 print("VM - Failed To postGuidedSpot")
                 self?.onSuccessPostGuidedSpotRequest.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import UIKit
 
-class SpotListViewModel {
+class SpotListViewModel: Serviceable {
     
     // MARK: - Properties
     
@@ -67,6 +67,10 @@ extension SpotListViewModel {
             case .success(let data):
                 self?.myAddress = data.area
                 self?.onSuccessGetAddress.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getAddress()
+                }
             default:
                 self?.onSuccessGetAddress.value = false
                 return
@@ -108,6 +112,10 @@ extension SpotListViewModel {
                 self?.isUpdated = spotList != self?.spotList
                 self?.spotList = spotList
                 self?.isPostSpotListSuccess.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postSpotList()
+                }
             default:
                 print("🥑Failed To Post")
                 self?.isPostSpotListSuccess.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class SpotReviewViewModel {
+class SpotReviewViewModel: Serviceable {
     
     let onSuccessGetAcornCount: ObservablePattern<Bool> = ObservablePattern(nil)
     
@@ -22,6 +22,10 @@ class SpotReviewViewModel {
                 self?.acornCount.value = data.acornCount
                 self?.onSuccessGetAcornCount.value = true
                 print(self?.acornCount.value, data.acornCount)
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getAcornCount()
+                }
             default:
                 print("VM - Fail to getAcornCount")
                 self?.onSuccessGetAcornCount.value = false
@@ -36,6 +40,10 @@ class SpotReviewViewModel {
             switch response {
             case .success(_):
                 self?.onSuccessPostReview.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postReview(spotID: spotID, acornCount: acornCount)
+                }
             default:
                 print("VM - Fail to postReview")
                 self?.onSuccessPostReview.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class SpotSearchViewModel {
+class SpotSearchViewModel: Serviceable {
     
     var longitude: Double
     
@@ -46,6 +46,10 @@ class SpotSearchViewModel {
                     )
                 }
                 self?.searchKeywordData.value = searchKeywords
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getSearchKeyword(keyword: keyword)
+                }
             default:
                 print("VM - Fail to getSearchKeyword")
                 self?.onSuccessGetSearchKeyword.value = false
@@ -66,6 +70,10 @@ class SpotSearchViewModel {
                 }
                 self?.searchSuggestionData.value = searchSuggestionData
                 self?.onSuccessGetSearchSuggestion.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getSearchSuggestion()
+                }
             default:
                 print("VM - Fail to getSearchSuggestion")
                 self?.onSuccessGetSearchSuggestion.value = false


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #31

## 🥔 **작업 내용**
토큰 리이슈 API를 연결하고, 모든 서버통신 분기처리에 적용해두었습니다.

## 🚨 참고 사항
아직 테스트를 못 해봐서, 서버 측에 엑세스 토큰 만료 시간 1분으로 조정해달라 하고 테스트해볼게요 !

테스트 완료했습니다 !

### 적용 방법
1. 서버통신 메소드를 호출하는 뷰모델은 Servicable 프로토콜을 상속
2. 서버통신 메소드 분기처리를 기존 .success과 .default 중간에 .reIssueJWT를 추가해주세요 !
```
case .success(let data):
     self?.localArea.value = data.area
     self?.onSuccessPostLocalArea.value = true
 case .reIssueJWT:
     self?.handleReissue { [weak self] in
         self?.postLocalArea()
     }
 default:
     print("Failed To Post")
     self?.onSuccessPostLocalArea.value = false
```
completion Handler 안에는 reIssue 완료 시 다시 실행할 서버통신 함수를 넣어주세용 ~

## 📸 스크린샷

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #31
