### PR TITLE
[FEAT] 내 프로필 조회 API 연결 (#24)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		151003EC2D5FBF7200409DF4 /* GetProfileResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */; };
+		151003EE2D5FC48B00409DF4 /* ProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003ED2D5FC48B00409DF4 /* ProfileService.swift */; };
+		151003F02D5FC4C600409DF4 /* ProfileTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003EF2D5FC4C600409DF4 /* ProfileTargetType.swift */; };
 		1517FD7F2D3961A800638173 /* CustomSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1517FD7E2D3961A800638173 /* CustomSlider.swift */; };
 		1533FCD12D55EE2600F985A0 /* ProfileBoxComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1533FCD02D55EE2600F985A0 /* ProfileBoxComponent.swift */; };
 		1547A6EB2D337F4100E96616 /* SpotListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A6EA2D337F4100E96616 /* SpotListView.swift */; };
@@ -216,6 +218,8 @@
 
 /* Begin PBXFileReference section */
 		151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProfileResponse.swift; sourceTree = "<group>"; };
+		151003ED2D5FC48B00409DF4 /* ProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileService.swift; sourceTree = "<group>"; };
+		151003EF2D5FC4C600409DF4 /* ProfileTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTargetType.swift; sourceTree = "<group>"; };
 		1517FD7E2D3961A800638173 /* CustomSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSlider.swift; sourceTree = "<group>"; };
 		1533FCD02D55EE2600F985A0 /* ProfileBoxComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileBoxComponent.swift; sourceTree = "<group>"; };
 		1547A6EA2D337F4100E96616 /* SpotListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListView.swift; sourceTree = "<group>"; };
@@ -444,6 +448,8 @@
 			isa = PBXGroup;
 			children = (
 				151003E82D5FBEF900409DF4 /* DTO */,
+				151003ED2D5FC48B00409DF4 /* ProfileService.swift */,
+				151003EF2D5FC4C600409DF4 /* ProfileTargetType.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1714,6 +1720,8 @@
 				D6FF82EB2D380AAF00090233 /* FavoriteSpotRankType.swift in Sources */,
 				D6D0F5152D36BA6500326F17 /* DislikeCollectionView.swift in Sources */,
 				74BF92072D38622B00B923E3 /* SpotDetailViewModel.swift in Sources */,
+				151003EE2D5FC48B00409DF4 /* ProfileService.swift in Sources */,
+				151003F02D5FC4C600409DF4 /* ProfileTargetType.swift in Sources */,
 				745C7E152D35AEC10074DBDB /* SpotSearchViewModel.swift in Sources */,
 				15CF62C22D577B600000A10F /* ProfileValidMessageType.swift in Sources */,
 				D6E452932D3AA47500CBED02 /* ProfileView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		151003EC2D5FBF7200409DF4 /* GetProfileResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */; };
 		1517FD7F2D3961A800638173 /* CustomSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1517FD7E2D3961A800638173 /* CustomSlider.swift */; };
 		1533FCD12D55EE2600F985A0 /* ProfileBoxComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1533FCD02D55EE2600F985A0 /* ProfileBoxComponent.swift */; };
 		1547A6EB2D337F4100E96616 /* SpotListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A6EA2D337F4100E96616 /* SpotListView.swift */; };
@@ -214,6 +215,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProfileResponse.swift; sourceTree = "<group>"; };
 		1517FD7E2D3961A800638173 /* CustomSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSlider.swift; sourceTree = "<group>"; };
 		1533FCD02D55EE2600F985A0 /* ProfileBoxComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileBoxComponent.swift; sourceTree = "<group>"; };
 		1547A6EA2D337F4100E96616 /* SpotListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListView.swift; sourceTree = "<group>"; };
@@ -438,6 +440,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		151003E72D5FBEE900409DF4 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				151003E82D5FBEF900409DF4 /* DTO */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		151003E82D5FBEF900409DF4 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		1533FCCF2D55EDD200F985A0 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -684,20 +702,20 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		741B58732D5ED20E0061CBF7 /* Type */ = {
-			isa = PBXGroup;
-			children = (
-				741B58742D5ED2150061CBF7 /* PhotoCollectionViewSizeType.swift */,
-			);
-			path = Type;
-			sourceTree = "<group>";
-		};
 		741429612D5D3CDF00B69528 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
 				741429622D5D3CE900B69528 /* SettingTableViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		741B58732D5ED20E0061CBF7 /* Type */ = {
+			isa = PBXGroup;
+			children = (
+				741B58742D5ED2150061CBF7 /* PhotoCollectionViewSizeType.swift */,
+			);
+			path = Type;
 			sourceTree = "<group>";
 		};
 		74220DD12D34361E000684BF /* Upload */ = {
@@ -947,6 +965,7 @@
 				D6AF15612D3E8A3700289683 /* Onboarding */,
 				743069872D3D2EDA0033178C /* Base */,
 				15CD25752D3FE2D800320006 /* SpotList */,
+				151003E72D5FBEE900409DF4 /* Profile */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1532,6 +1551,7 @@
 				15C0ED522D429F7400C9ED83 /* SkeletonView.swift in Sources */,
 				15A48BFA2D574BA5003C2421 /* ProfileEditView.swift in Sources */,
 				74BF92272D39957600B923E3 /* StickyHeaderView.swift in Sources */,
+				151003EC2D5FBF7200409DF4 /* GetProfileResponse.swift in Sources */,
 				746F15B92D3E212D003EA031 /* PostLocalAreaResponse.swift in Sources */,
 				746F15BD2D3E225E003EA031 /* LocalVerificationService.swift in Sources */,
 				1517FD7F2D3961A800638173 /* CustomSlider.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
@@ -18,4 +18,9 @@ enum HeaderType {
         return ["Content-Type" : "application/json", "Authorization" : "Bearer " + token]
     }
     
+    static func tokenOnly() -> [String:String] {
+        let token = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) ?? ""
+        return ["Authorization" : "Bearer " + token]
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Network/Base/ACService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/ACService.swift
@@ -27,4 +27,6 @@ final class ACService {
     
     lazy var spotListService = SpotListService()
     
+    lazy var profileService = ProfileService()
+    
 }

--- a/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetProfileResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetProfileResponse.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+
+struct GetProfileResponse: Decodable {
+    
+    let image: String
+    
+    let nickname: String
+    
+    let leftAcornCount: Int
+    
+    let birthDate: String?
+    
+    let verifiedAreaList: [VerifiedArea]
+    
+}
+
+struct VerifiedArea: Decodable {
+    
+    let id: Int64
+    
+    let name: String
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetProfileResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetProfileResponse.swift
@@ -1,0 +1,8 @@
+//
+//  GetProfileResponse.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/15/25.
+//
+
+import Foundation

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
@@ -1,0 +1,8 @@
+//
+//  ProfileService.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/15/25.
+//
+
+import Foundation

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
@@ -6,3 +6,31 @@
 //
 
 import Foundation
+
+import Moya
+
+protocol ProfileServiceProtocol {
+
+    func getProfile(completion: @escaping (NetworkResult<GetProfileResponse>) -> Void)
+
+}
+
+final class ProfileService: BaseService<ProfileTargetType>, ProfileServiceProtocol {
+    
+    func getProfile(completion: @escaping (NetworkResult<GetProfileResponse>) -> Void) {
+        self.provider.request(.getProfile) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetProfileResponse> = self.judgeStatus(
+                    statusCode: response.statusCode,
+                    data: response.data,
+                    type: GetProfileResponse.self
+                )
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
@@ -6,3 +6,50 @@
 //
 
 import Foundation
+
+import Moya
+
+enum ProfileTargetType {
+    
+    case getProfile
+
+}
+
+extension ProfileTargetType: TargetType {
+
+    var method: Moya.Method {
+        switch self {
+        case .getProfile:
+            return .get
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .getProfile:
+            return utilPath + "members/me"
+        }
+    }
+    
+    var parameter: [String : Any]?  {
+        switch self {
+        default:
+            return .none
+        }
+    }
+
+    var task: Task {
+        switch self {
+        default:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String : String]? {
+        switch self {
+        case .getProfile:
+            return HeaderType.tokenOnly()
+        }
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  ProfileTargetType.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/15/25.
+//
+
+import Foundation

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/Model/ProfileModel.swift
@@ -36,7 +36,7 @@ struct UserInfoEditModel {
 
 struct VerifiedAreaModel: Equatable {
     
-    let id: Int
+    let id: Int64
     
     var name: String
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -147,15 +147,13 @@ private extension ProfileEditViewController {
     
     func bindData() {
         // NOTE: 기본 데이터 바인딩
-        guard let userInfo = viewModel.userInfo.value else { return }
         profileEditView.do {
-            $0.setProfileImage(userInfo.profileImageURL)
-            $0.nicknameTextField.text = userInfo.nickname
-            $0.setNicknameLengthLabel(
-                countPhoneme(text: userInfo.nickname),
-                viewModel.maxNicknameLength
-                )
-            $0.birthDateTextField.text = userInfo.birthDate
+            $0.setProfileImage(viewModel.userInfo.profileImageURL)
+            $0.nicknameTextField.text = viewModel.userInfo.nickname
+            $0.setNicknameLengthLabel(countPhoneme(text: viewModel.userInfo.nickname),
+                                      viewModel.maxNicknameLength
+            )
+            $0.birthDateTextField.text = viewModel.userInfo.birthDate
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -52,6 +52,7 @@ final class ProfileView: BaseView {
             $0.backgroundColor = .gray7 // NOTE: Skeleton
             $0.layer.cornerRadius = profileImageSize / 2
             $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
         }
         
         profileEditButton.do {

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -29,6 +29,7 @@ class ProfileViewController: BaseNavViewController {
         super.viewWillAppear(animated)
         
         self.tabBarController?.tabBar.isHidden = false
+        viewModel.getProfile()
     }
     
     override func setHierarchy() {

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -89,17 +89,16 @@ private extension ProfileViewController {
             }
         }
         
-        viewModel.userInfo.bind { [weak self] userInfo in
+        viewModel.onGetProfileSuccess.bind { [weak self] onSuccess in
             guard let self = self,
-                  let userInfo = userInfo else { return }
-            
+                  let onSuccess = onSuccess else { return }
+            // TODO: onSuccess 분기처리
             // TODO: 인증동네 추후 여러개로 수정(Sprint3)
-            let firstAreaName: String = self.viewModel.userInfo.value?.verifiedAreaList.first?.name ?? "impossible"
-            
+            let firstAreaName: String = self.viewModel.userInfo.verifiedAreaList.first?.name ?? "impossible"
             profileView.do {
-                $0.setProfileImage(userInfo.profileImageURL)
-                $0.setNicknameLabel(userInfo.nickname)
-                $0.setAcornCountBox(userInfo.possessingAcorns)
+                $0.setProfileImage(self.viewModel.userInfo.profileImageURL)
+                $0.setNicknameLabel(self.viewModel.userInfo.nickname)
+                $0.setAcornCountBox(self.viewModel.userInfo.possessingAcorns)
                 $0.setVerifiedAreaBox(areaName: firstAreaName)
             }
         }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -13,16 +13,16 @@ class ProfileViewModel {
     
     var onLoginSuccess: ObservablePattern<Bool> = ObservablePattern(AuthManager.shared.hasToken)
     
+    var onGetProfileSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+    
     var verifiedAreaListEditing: ObservablePattern<[VerifiedAreaModel]> = ObservablePattern(nil)
     
-    var userInfo: ObservablePattern<UserInfoModel> = ObservablePattern(
-        UserInfoModel(
+    var userInfo = UserInfoModel(
             profileImageURL: "",
             nickname: "김유림",
             birthDate: nil,
             verifiedAreaList: [VerifiedAreaModel(id: 1, name: "유림동")],
             possessingAcorns: 0
-        )
     )
     
     let maxNicknameLength: Int = 16
@@ -31,17 +31,17 @@ class ProfileViewModel {
     // MARK: - Initializer
     
     init() {
-        verifiedAreaListEditing.value = userInfo.value?.verifiedAreaList
+        verifiedAreaListEditing.value = userInfo.verifiedAreaList
     }
     
     
     // MARK: - Methods
     
     func updateUserInfo(newUserInfo: UserInfoEditModel) {
-        userInfo.value?.profileImageURL = newUserInfo.profileImageURL
-        userInfo.value?.nickname = newUserInfo.nickname
-        userInfo.value?.birthDate = newUserInfo.birthDate
-        userInfo.value?.verifiedAreaList = newUserInfo.verifiedAreaList
+        userInfo.profileImageURL = newUserInfo.profileImageURL
+        userInfo.nickname = newUserInfo.nickname
+        userInfo.birthDate = newUserInfo.birthDate
+        userInfo.verifiedAreaList = newUserInfo.verifiedAreaList
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -44,4 +44,28 @@ class ProfileViewModel {
         userInfo.verifiedAreaList = newUserInfo.verifiedAreaList
     }
     
+    
+    // MARK: - Networking
+    
+    func getProfile() {
+        ACService.shared.profileService.getProfile { [weak self] response in
+            guard let self = self else { return }
+            switch response {
+            case .success(let data):
+                let newUserInfo = UserInfoModel(
+                    profileImageURL: data.image,
+                    nickname: data.nickname,
+                    verifiedAreaList: data.verifiedAreaList.map {
+                        return VerifiedAreaModel(id: $0.id, name: $0.name)
+                    },
+                    possessingAcorns: data.leftAcornCount
+                )
+                userInfo = newUserInfo
+                onGetProfileSuccess.value = true
+            default:
+                onGetProfileSuccess.value = false
+            }
+        }
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -55,6 +55,7 @@ class ProfileViewModel: Serviceable {
                 let newUserInfo = UserInfoModel(
                     profileImageURL: data.image,
                     nickname: data.nickname,
+                    birthDate: data.birthDate,
                     verifiedAreaList: data.verifiedAreaList.map {
                         return VerifiedAreaModel(id: $0.id, name: $0.name)
                     },

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class ProfileViewModel {
+class ProfileViewModel: Serviceable {
     
     // MARK: - Properties
     
@@ -62,6 +62,10 @@ class ProfileViewModel {
                 )
                 userInfo = newUserInfo
                 onGetProfileSuccess.value = true
+            case .reIssueJWT:
+                self.handleReissue {
+                    self.getProfile()
+                }
             default:
                 onGetProfileSuccess.value = false
             }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #24 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- HeaderType에 tokenOnly()를 추가했습니다.
- 내 프로필 조회 API를 연결했습니다.
- 토큰 재발급 분기처리 했습니다.
- ProfileViewModel에서 userInfo 프로퍼티의 옵저버블을 벗기고, onGetProfileSuccess 옵저버블을 생성했습니다.

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->
verifiedAreaList 필드의 경우, 지금 서버에서 verifiedArea로 보내고 있는데 곧 verifiedAreaList로 수정 예정이라고 합니다.
그래서 코드는 verifiedAreaList라고 해뒀어요!! 서버가 수정하기 전까지는 디코딩 에러 날 겁니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/763d3edc-d214-4289-aa49-6a49de6dd4e3" />


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 11 Pro|<img src = "https://github.com/user-attachments/assets/9cb4ada7-560e-4f08-9953-cd50dcfdc5fd" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #24
