### PR TITLE
[Fix] 리이슈에 실패했을 경우 Splash로 이동 전에 UserDefaults 토큰 삭제 (#37)

### DIFF
--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -51,11 +51,13 @@ extension Serviceable {
                         print("❄️ 기존 서버통신 다시 성공")
                         retryAction()
                     } else {
+                        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefaults.accessToken)
                         self.navigateToSplash()
                     }
                 }
             } catch {
                 DispatchQueue.main.async {
+                    UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefaults.accessToken)
                     self.navigateToSplash()
                 }
             }

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -51,13 +51,17 @@ extension Serviceable {
                         print("❄️ 기존 서버통신 다시 성공")
                         retryAction()
                     } else {
-                        UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefaults.accessToken)
+                        for key in UserDefaults.standard.dictionaryRepresentation().keys {
+                            UserDefaults.standard.removeObject(forKey: key.description)
+                        }
                         self.navigateToSplash()
                     }
                 }
             } catch {
                 DispatchQueue.main.async {
-                    UserDefaults.standard.removeObject(forKey: StringLiterals.UserDefaults.accessToken)
+                    for key in UserDefaults.standard.dictionaryRepresentation().keys {
+                        UserDefaults.standard.removeObject(forKey: key.description)
+                    }
                     self.navigateToSplash()
                 }
             }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #37 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
Refresh Token이 유효하지 않아서 reissue에 실패하면 Splash로 돌아가게 되어 있습니다.
그런데 Splash로 돌아가도 UserDefault에 loginToken 값이 있기 때문에 로그인 상태로 인식하고 앱 플로우에 진입해 버립니다. 
때문에 앱 플로우에 진입했다가 리이슈 실패하고 다시 Splash로 돌아가는 게 무한 반복됩니다.

문제 해결을 위해 reissue에 실패했을 때 UserDefault의 accessToken을 삭제하는 코드를 추가했습니다.


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #37 
