### PR TITLE
[FEAT] 닉네임 유효성 검증 시 로딩 로띠 활성화 (#54)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileEditTextField.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileEditTextField.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import Lottie
+
 class ProfileEditTextField: UITextField {
     
     // MARK: - Internal Property
@@ -22,7 +24,13 @@ class ProfileEditTextField: UITextField {
     
     private let clearButtonSpacing: CGFloat = 16
     
+    private let rightItemView = UIView()
+    
     private let clearButton = UIButton()
+    
+    private let loadingRightView = UIView()
+    
+    private let animationView = LottieAnimationView(name: "loadingWhite")
     
     
     // MARK: - Initializer
@@ -30,6 +38,8 @@ class ProfileEditTextField: UITextField {
     override init(frame: CGRect) {
         super.init(frame: .zero)
         
+        setHierarchy()
+        setLayout()
         setStyle()
         addTarget()
         addDoneButtonToKeyboard()
@@ -40,10 +50,27 @@ class ProfileEditTextField: UITextField {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private func setHierarchy() {
+        loadingRightView.addSubview(animationView)
+    }
+    
+    private func setLayout() {
+        animationView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.leading.equalToSuperview().offset(clearButtonSpacing)
+            $0.trailing.equalToSuperview().offset(-horizontalInset)
+            $0.size.equalTo(28)
+        }
+    }
+    
     private func setStyle() {
         setTextFieldStyle()
         
         setKeyboardStyle()
+        
+        animationView.do {
+            $0.isHidden = true
+        }
         
         clearButton.do {
             var config = UIButton.Configuration.plain()
@@ -206,4 +233,22 @@ extension ProfileEditTextField {
         clearButton.isHidden = isHidden
     }
     
+    func startCheckingAnimation() {
+        self.rightView = loadingRightView
+        animationView.isHidden = false
+        animationView.loopMode = .loop
+        animationView.play()
+    }
+    
+    func endCheckingAnimation() {
+        self.rightView = clearButton
+        animationView.isHidden = true
+        animationView.loopMode = .playOnce
+        
+        animationView.play(completion: { (isFinished) in
+            if isFinished {
+                self.animationView.stop()
+            }
+        })
+    }
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -24,6 +24,8 @@ class ProfileEditViewController: BaseNavViewController {
     
     private var isNicknameAvailable: Bool = true {
         didSet {
+            // NOTE: 검증이 완료되었으므로 로딩 로띠 종료
+            profileEditView.nicknameTextField.endCheckingAnimation()
             checkSaveAvailability()
         }
     }
@@ -193,7 +195,7 @@ private extension ProfileEditViewController {
         viewModel.onGetNicknameValiditySuccess.bind { [weak self] onSuccess in
             guard let self = self,
                   let onSuccess = onSuccess else { return }
-            print("🥑onSuccessnickname: \(onSuccess)")
+            
             if onSuccess {
                 profileEditView.setNicknameValidMessage(.nicknameOK)
                 profileEditView.nicknameTextField.changeBorderColor(toRed: false)
@@ -277,7 +279,9 @@ private extension ProfileEditViewController {
             // NOTE: 닉네임 필드 값이 변하면 일단 저장 막기 (유효성검사를 0.5초 뒤에 하기 때문에)
             isNicknameAvailable = false
             
+            // NOTE: clear버튼 숨기고 로딩 로띠 실행
             profileEditView.nicknameTextField.hideClearButton(isHidden: text.isEmpty)
+            profileEditView.nicknameTextField.startCheckingAnimation()
             
             // NOTE: 텍스트 변하면 유효성 메시지 숨김, 텍스트필드 UI 변경
             profileEditView.setNicknameValidMessage(.none)
@@ -508,10 +512,9 @@ private extension ProfileEditViewController {
     // MARK: - 닉네임
     
     func checkNicknameValidity() {
+        
         let text = profileEditView.nicknameTextField.text ?? ""
         let phonemeCount = countPhoneme(text: text)
-        
-        // TODO: 빙글빙글 로띠 활성화
         
         // NOTE: 닉네임을 입력해주세요.
         if phonemeCount == 0 {

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -512,7 +512,6 @@ private extension ProfileEditViewController {
     // MARK: - 닉네임
     
     func checkNicknameValidity() {
-        
         let text = profileEditView.nicknameTextField.text ?? ""
         let phonemeCount = countPhoneme(text: text)
         


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #54 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
입력중일 때 로딩 로띠를 활성화하고, 유효성 검증이 끝나면 로띠를 멈춥니다

## 📸 스크린샷

https://github.com/user-attachments/assets/14c8f9e8-90d9-4a22-889d-7f6cb3d724ec


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #54 