### PR TITLE
[FEAT] 기본 에러 뷰 UI 구현 (#61)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		15CF62C72D57DE680000A10F /* ProfileEditTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CF62C62D57DE680000A10F /* ProfileEditTextField.swift */; };
 		15D122292D58BD0200E79866 /* DayOfMonthType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D122282D58BD0200E79866 /* DayOfMonthType.swift */; };
 		15DC053F2D623DD400B752DD /* PostLogoutRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DC053E2D623DD400B752DD /* PostLogoutRequest.swift */; };
+		15F45F842D6664C900BD6B9C /* BaseErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F45F832D6664C900BD6B9C /* BaseErrorView.swift */; };
 		4C6B2F332D65A15D0089BCB6 /* WithdrawalTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F312D65A15D0089BCB6 /* WithdrawalTargetType.swift */; };
 		4C6B2F342D65A15D0089BCB6 /* WithdrawalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F302D65A15D0089BCB6 /* WithdrawalService.swift */; };
 		4C6B2F352D65A15D0089BCB6 /* WithdrawalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F2E2D65A15D0089BCB6 /* WithdrawalRequest.swift */; };
@@ -312,6 +313,7 @@
 		15CF62C62D57DE680000A10F /* ProfileEditTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditTextField.swift; sourceTree = "<group>"; };
 		15D122282D58BD0200E79866 /* DayOfMonthType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfMonthType.swift; sourceTree = "<group>"; };
 		15DC053E2D623DD400B752DD /* PostLogoutRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLogoutRequest.swift; sourceTree = "<group>"; };
+		15F45F832D6664C900BD6B9C /* BaseErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorView.swift; sourceTree = "<group>"; };
 		4C6B2F2E2D65A15D0089BCB6 /* WithdrawalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalRequest.swift; sourceTree = "<group>"; };
 		4C6B2F302D65A15D0089BCB6 /* WithdrawalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalService.swift; sourceTree = "<group>"; };
 		4C6B2F312D65A15D0089BCB6 /* WithdrawalTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalTargetType.swift; sourceTree = "<group>"; };
@@ -1191,6 +1193,7 @@
 				748D6FA52D2C3F40007690B4 /* BaseView.swift */,
 				748D6FA32D2C3C44007690B4 /* BaseNavViewController.swift */,
 				D6E816A92D624DDB001E4EBF /* BaseTabelViewCell.swift */,
+				15F45F832D6664C900BD6B9C /* BaseErrorView.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1837,6 +1840,7 @@
 				74BF92112D391FFE00B923E3 /* LocalVerificationViewController.swift in Sources */,
 				74BF92122D391FFE00B923E3 /* LocalMapViewController.swift in Sources */,
 				D6E8168E2D6228F5001E4EBF /* WithdrawalViewController.swift in Sources */,
+				15F45F842D6664C900BD6B9C /* BaseErrorView.swift in Sources */,
 				746261692D3EA33300A4E84F /* PostReviewRequest.swift in Sources */,
 				15CD257E2D3FF4F200320006 /* SpotListTargetType.swift in Sources */,
 				156D925C2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -19,7 +19,7 @@ enum StringLiterals {
         
     }
     
-    enum ErrorMessages {
+    enum Error {
         
         static let checkInternet = "인터넷 연결을 확인해주세요"
         

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -19,6 +19,14 @@ enum StringLiterals {
         
     }
     
+    enum ErrorMessages {
+        
+        static let checkInternet = "인터넷 연결을 확인해주세요"
+        
+        static let reload = "다시 불러오기"
+        
+    }
+    
     enum Login {
         
         static let googleLogin = "Google로 계속하기"

--- a/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/Contents.json
+++ b/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/ic_error_1_140.imageset/Contents.json
+++ b/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/ic_error_1_140.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_error_1_140.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/ic_error_1_140.imageset/ic_error_1_140.svg
+++ b/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/BaseIcon/ic_error_1_140.imageset/ic_error_1_140.svg
@@ -1,0 +1,135 @@
+<svg width="141" height="140" viewBox="0 0 141 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M83.7957 16.9389L83.3382 17.7883C82.4825 19.3891 82.372 21.1581 82.8551 22.7337C58.6438 18.0852 36.2537 27.1853 31.1424 44.6392C28.8987 52.3006 30.3267 60.4025 34.5715 67.8557C33.8473 69.4921 33.2222 71.1951 32.7055 72.9594C26.3718 94.5874 38.7342 117.244 60.3176 123.565C81.9011 129.886 104.532 117.477 110.866 95.8486C111.383 94.0826 111.776 92.3098 112.049 90.5395C119.64 86.5535 125.211 80.503 127.454 72.8437C132.565 55.388 118.618 35.6452 95.7196 26.5002C97.0081 25.4065 97.8785 23.8055 97.9831 21.9423L98.0375 20.9749C98.209 17.9741 96.286 15.2489 93.4015 14.4042L91.3111 13.792C88.3769 12.9328 85.2385 14.2431 83.7957 16.9389Z" fill="url(#paint0_linear_4022_34952)"/>
+<foreignObject x="5.70031" y="14.2198" width="113.283" height="126.986"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3.23px);clip-path:url(#bgblur_0_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g data-figma-bg-blur-radius="6.46375">
+<mask id="path-2-inside-1_4022_34952" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M54.9101 25.8158L54.7098 26.7595C54.3384 28.5363 54.7295 30.2651 55.6361 31.6414C31.0941 33.9847 12.1641 49.0107 12.1641 67.1976C12.1641 75.1798 15.8106 82.5531 21.9777 88.5125C21.7425 90.2872 21.6211 92.0979 21.6211 93.937C21.6211 116.473 39.8528 134.743 62.3427 134.743C84.8326 134.743 103.064 116.473 103.064 93.937C103.064 92.0975 102.943 90.2865 102.708 88.5116C108.874 82.5523 112.52 75.1794 112.52 67.1976C112.52 49.0088 93.5862 33.9816 69.0405 31.6406C69.9697 30.2288 70.3551 28.4477 69.9319 26.6302L69.7121 25.6865C69.0334 22.7585 66.422 20.6836 63.4164 20.6836H61.2381C58.1808 20.6836 55.5371 22.8231 54.9101 25.8158Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M54.9101 25.8158L54.7098 26.7595C54.3384 28.5363 54.7295 30.2651 55.6361 31.6414C31.0941 33.9847 12.1641 49.0107 12.1641 67.1976C12.1641 75.1798 15.8106 82.5531 21.9777 88.5125C21.7425 90.2872 21.6211 92.0979 21.6211 93.937C21.6211 116.473 39.8528 134.743 62.3427 134.743C84.8326 134.743 103.064 116.473 103.064 93.937C103.064 92.0975 102.943 90.2865 102.708 88.5116C108.874 82.5523 112.52 75.1794 112.52 67.1976C112.52 49.0088 93.5862 33.9816 69.0405 31.6406C69.9697 30.2288 70.3551 28.4477 69.9319 26.6302L69.7121 25.6865C69.0334 22.7585 66.422 20.6836 63.4164 20.6836H61.2381C58.1808 20.6836 55.5371 22.8231 54.9101 25.8158Z" fill="#FFE1CB" fill-opacity="0.4"/>
+<path d="M54.7098 26.7595L54.0775 26.6253L54.0771 26.6273L54.7098 26.7595ZM54.9101 25.8158L55.5424 25.9501L55.5428 25.9483L54.9101 25.8158ZM55.6361 31.6414L55.6975 32.2848L56.7666 32.1827L56.1759 31.2858L55.6361 31.6414ZM21.9777 88.5125L22.6185 88.5975L22.6614 88.2743L22.4269 88.0477L21.9777 88.5125ZM102.708 88.5116L102.258 88.0468L102.024 88.2733L102.067 88.5965L102.708 88.5116ZM69.0405 31.6406L68.5006 31.2853L67.9102 32.1821L68.9791 32.2841L69.0405 31.6406ZM69.9319 26.6302L69.3023 26.7768V26.7768L69.9319 26.6302ZM69.7121 25.6865L69.0824 25.8325L69.0826 25.8331L69.7121 25.6865ZM55.342 26.8938L55.5424 25.9501L54.2779 25.6816L54.0775 26.6253L55.342 26.8938ZM56.1759 31.2858C55.3596 30.0466 55.0079 28.4924 55.3425 26.8918L54.0771 26.6273C53.6689 28.5802 54.0995 30.4837 55.0963 31.9969L56.1759 31.2858ZM55.5746 30.9979C43.1946 32.18 32.2017 36.5628 24.2898 42.976C16.3769 49.3901 11.5177 57.8643 11.5177 67.1976H12.8104C12.8104 58.344 17.4163 50.2117 25.1039 43.9803C32.7925 37.748 43.5356 33.4461 55.6975 32.2848L55.5746 30.9979ZM11.5177 67.1976C11.5177 75.3886 15.2617 82.9216 21.5286 88.9773L22.4269 88.0477C16.3595 82.1847 12.8104 74.9711 12.8104 67.1976H11.5177ZM21.337 88.4276C21.098 90.2303 20.9747 92.0694 20.9747 93.937H22.2675C22.2675 92.1264 22.387 90.344 22.6185 88.5975L21.337 88.4276ZM20.9747 93.937C20.9747 116.829 39.4945 135.389 62.3427 135.389V134.096C40.211 134.096 22.2675 116.118 22.2675 93.937H20.9747ZM62.3427 135.389C85.1909 135.389 103.711 116.829 103.711 93.937H102.418C102.418 116.118 84.4744 134.096 62.3427 134.096V135.389ZM103.711 93.937C103.711 92.0691 103.587 90.2297 103.348 88.4266L102.067 88.5965C102.298 90.3434 102.418 92.126 102.418 93.937H103.711ZM103.157 88.9764C109.423 82.9208 113.167 75.3881 113.167 67.1976H111.874C111.874 74.9706 108.325 82.1839 102.258 88.0468L103.157 88.9764ZM113.167 67.1976C113.167 57.8633 108.306 49.3883 100.392 42.974C92.4786 36.5605 81.4838 32.178 69.1019 30.9972L68.9791 32.2841C81.1429 33.4441 91.8879 37.7458 99.578 43.9783C107.267 50.21 111.874 58.343 111.874 67.1976H113.167ZM69.3023 26.7768C69.6834 28.4135 69.3372 30.0142 68.5006 31.2853L69.5804 31.996C70.6023 30.4435 71.0267 28.4819 70.5614 26.4837L69.3023 26.7768ZM69.0826 25.8331L69.3023 26.7768L70.5614 26.4837L70.3417 25.5399L69.0826 25.8331ZM63.4164 21.33C66.1214 21.33 68.4717 23.1975 69.0824 25.8325L70.3418 25.5406C69.5952 22.3195 66.7227 20.0372 63.4164 20.0372V21.33ZM61.2381 21.33H63.4164V20.0372H61.2381V21.33ZM55.5428 25.9483C56.1068 23.2561 58.4855 21.33 61.2381 21.33V20.0372C57.876 20.0372 54.9674 22.3901 54.2775 25.6833L55.5428 25.9483Z" fill="url(#paint1_linear_4022_34952)" mask="url(#path-2-inside-1_4022_34952)"/>
+</g>
+<foreignObject x="51.8673" y="60.0001" width="21.0233" height="40.5018"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_1_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter1_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M68.531 90.0294C68.531 93.3608 65.7888 96.1438 62.4139 96.1438C59.039 96.1438 56.2266 93.3608 56.2266 90.0294V70.3954C56.2266 67.0572 59.039 64.3574 62.4139 64.3574C65.7888 64.3574 68.531 67.0572 68.531 70.3954V90.0294Z" fill="white" fill-opacity="0.5" shape-rendering="crispEdges"/>
+<path d="M68.531 90.0294C68.531 93.3608 65.7888 96.1438 62.4139 96.1438C59.039 96.1438 56.2266 93.3608 56.2266 90.0294V70.3954C56.2266 67.0572 59.039 64.3574 62.4139 64.3574C65.7888 64.3574 68.531 67.0572 68.531 70.3954V90.0294Z" stroke="url(#paint2_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="110.727" y="86.7989" width="20.8709" height="27.6912"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_2_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter2_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M122.477 107.723C121.714 109.655 119.485 110.641 117.528 109.867C115.57 109.093 114.577 106.834 115.341 104.902L119.842 93.5139C120.608 91.5776 122.858 90.6565 124.815 91.4303C126.773 92.2041 127.744 94.3987 126.979 96.335L122.477 107.723Z" fill="#FF8950" fill-opacity="0.35" shape-rendering="crispEdges"/>
+<path d="M122.477 107.723C121.714 109.655 119.485 110.641 117.528 109.867C115.57 109.093 114.577 106.834 115.341 104.902L119.842 93.5139C120.608 91.5776 122.858 90.6565 124.815 91.4303C126.773 92.2041 127.744 94.3987 126.979 96.335L122.477 107.723Z" stroke="url(#paint3_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="8.46494" y="7.32431" width="16.6951" height="22.5174"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_3_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter3_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M20.6889 21.9795C21.1134 23.4019 20.2972 24.9396 18.8562 25.3697C17.4151 25.7997 15.8597 24.9697 15.4352 23.5473L12.9334 15.164C12.5081 13.7387 13.3649 12.2276 14.8059 11.7975C16.247 11.3675 17.7618 12.1709 18.1871 13.5962L20.6889 21.9795Z" fill="#FF8950" fill-opacity="0.35" shape-rendering="crispEdges"/>
+<path d="M20.6889 21.9795C21.1134 23.4019 20.2972 24.9396 18.8562 25.3697C17.4151 25.7997 15.8597 24.9697 15.4352 23.5473L12.9334 15.164C12.5081 13.7387 13.3649 12.2276 14.8059 11.7975C16.247 11.3675 17.7618 12.1709 18.1871 13.5962L20.6889 21.9795Z" stroke="url(#paint4_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="51.8673" y="103.065" width="21.0233" height="21.0193"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_4_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter4_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M62.4139 119.726C59.039 119.726 56.2266 116.924 56.2266 113.578C56.2266 110.217 59.039 107.422 62.4139 107.422C65.7888 107.422 68.531 110.154 68.531 113.501C68.531 116.924 65.7888 119.726 62.4139 119.726Z" fill="white" fill-opacity="0.5" shape-rendering="crispEdges"/>
+<path d="M62.4139 119.726C59.039 119.726 56.2266 116.924 56.2266 113.578C56.2266 110.217 59.039 107.422 62.4139 107.422C65.7888 107.422 68.531 110.154 68.531 113.501C68.531 116.924 65.7888 119.726 62.4139 119.726Z" stroke="url(#paint5_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="105.32" y="111.787" width="16.3943" height="16.3807"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_5_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter5_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M112.119 123.548C110.162 122.774 109.173 120.504 109.94 118.563C110.711 116.613 112.983 115.637 114.94 116.411C116.898 117.185 117.862 119.398 117.095 121.339C116.31 123.325 114.077 124.321 112.119 123.548Z" fill="#FF8950" fill-opacity="0.35" shape-rendering="crispEdges"/>
+<path d="M112.119 123.548C110.162 122.774 109.173 120.504 109.94 118.563C110.711 116.613 112.983 115.637 114.94 116.411C116.898 117.185 117.862 119.398 117.095 121.339C116.31 123.325 114.077 124.321 112.119 123.548Z" stroke="url(#paint6_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="13.9688" y="25.711" width="14.1873" height="14.1971"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.05px);clip-path:url(#bgblur_6_4022_34952_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter6_d_4022_34952)" data-figma-bg-blur-radius="4.10147">
+<path d="M21.862 35.438C20.421 35.868 18.8632 35.03 18.4367 33.601C18.0085 32.166 18.8532 30.6143 20.2942 30.1843C21.7352 29.7542 23.2542 30.5713 23.6806 32.0004C24.1169 33.4622 23.3031 35.0079 21.862 35.438Z" fill="#FF8950" fill-opacity="0.35" shape-rendering="crispEdges"/>
+<path d="M21.862 35.438C20.421 35.868 18.8632 35.03 18.4367 33.601C18.0085 32.166 18.8532 30.6143 20.2942 30.1843C21.7352 29.7542 23.2542 30.5713 23.6806 32.0004C24.1169 33.4622 23.3031 35.0079 21.862 35.438Z" stroke="url(#paint7_linear_4022_34952)" stroke-width="0.512684" shape-rendering="crispEdges"/>
+</g>
+<defs>
+<clipPath id="bgblur_0_4022_34952_clip_path"><path transform="translate(-5.70031 -14.2198)" fill-rule="evenodd" clip-rule="evenodd" d="M54.9101 25.8158L54.7098 26.7595C54.3384 28.5363 54.7295 30.2651 55.6361 31.6414C31.0941 33.9847 12.1641 49.0107 12.1641 67.1976C12.1641 75.1798 15.8106 82.5531 21.9777 88.5125C21.7425 90.2872 21.6211 92.0979 21.6211 93.937C21.6211 116.473 39.8528 134.743 62.3427 134.743C84.8326 134.743 103.064 116.473 103.064 93.937C103.064 92.0975 102.943 90.2865 102.708 88.5116C108.874 82.5523 112.52 75.1794 112.52 67.1976C112.52 49.0088 93.5862 33.9816 69.0405 31.6406C69.9697 30.2288 70.3551 28.4477 69.9319 26.6302L69.7121 25.6865C69.0334 22.7585 66.422 20.6836 63.4164 20.6836H61.2381C58.1808 20.6836 55.5371 22.8231 54.9101 25.8158Z"/>
+</clipPath><filter id="filter1_d_4022_34952" x="51.8673" y="60.0001" width="21.0233" height="40.5018" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_1_4022_34952_clip_path"><path transform="translate(-51.8673 -60.0001)" d="M68.531 90.0294C68.531 93.3608 65.7888 96.1438 62.4139 96.1438C59.039 96.1438 56.2266 93.3608 56.2266 90.0294V70.3954C56.2266 67.0572 59.039 64.3574 62.4139 64.3574C65.7888 64.3574 68.531 67.0572 68.531 70.3954V90.0294Z"/>
+</clipPath><filter id="filter2_d_4022_34952" x="110.727" y="86.7989" width="20.8709" height="27.6912" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_2_4022_34952_clip_path"><path transform="translate(-110.727 -86.7989)" d="M122.477 107.723C121.714 109.655 119.485 110.641 117.528 109.867C115.57 109.093 114.577 106.834 115.341 104.902L119.842 93.5139C120.608 91.5776 122.858 90.6565 124.815 91.4303C126.773 92.2041 127.744 94.3987 126.979 96.335L122.477 107.723Z"/>
+</clipPath><filter id="filter3_d_4022_34952" x="8.46494" y="7.32431" width="16.6951" height="22.5174" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_3_4022_34952_clip_path"><path transform="translate(-8.46494 -7.32431)" d="M20.6889 21.9795C21.1134 23.4019 20.2972 24.9396 18.8562 25.3697C17.4151 25.7997 15.8597 24.9697 15.4352 23.5473L12.9334 15.164C12.5081 13.7387 13.3649 12.2276 14.8059 11.7975C16.247 11.3675 17.7618 12.1709 18.1871 13.5962L20.6889 21.9795Z"/>
+</clipPath><filter id="filter4_d_4022_34952" x="51.8673" y="103.065" width="21.0233" height="21.0193" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_4_4022_34952_clip_path"><path transform="translate(-51.8673 -103.065)" d="M62.4139 119.726C59.039 119.726 56.2266 116.924 56.2266 113.578C56.2266 110.217 59.039 107.422 62.4139 107.422C65.7888 107.422 68.531 110.154 68.531 113.501C68.531 116.924 65.7888 119.726 62.4139 119.726Z"/>
+</clipPath><filter id="filter5_d_4022_34952" x="105.32" y="111.787" width="16.3943" height="16.3807" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_5_4022_34952_clip_path"><path transform="translate(-105.32 -111.787)" d="M112.119 123.548C110.162 122.774 109.173 120.504 109.94 118.563C110.711 116.613 112.983 115.637 114.94 116.411C116.898 117.185 117.862 119.398 117.095 121.339C116.31 123.325 114.077 124.321 112.119 123.548Z"/>
+</clipPath><filter id="filter6_d_4022_34952" x="13.9688" y="25.711" width="14.1873" height="14.1971" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2.05073" dy="2.05073"/>
+<feGaussianBlur stdDeviation="1.02537"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.329412 0 0 0 0 0.00784314 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4022_34952"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4022_34952" result="shape"/>
+</filter>
+<clipPath id="bgblur_6_4022_34952_clip_path"><path transform="translate(-13.9688 -25.711)" d="M21.862 35.438C20.421 35.868 18.8632 35.03 18.4367 33.601C18.0085 32.166 18.8532 30.6143 20.2942 30.1843C21.7352 29.7542 23.2542 30.5713 23.6806 32.0004C24.1169 33.4622 23.3031 35.0079 21.862 35.438Z"/>
+</clipPath><linearGradient id="paint0_linear_4022_34952" x1="118.165" y1="31.026" x2="60.3147" y2="123.564" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F24B00"/>
+<stop offset="1" stop-color="#FF5402"/>
+</linearGradient>
+<linearGradient id="paint1_linear_4022_34952" x1="28.1391" y1="33.9716" x2="122.878" y2="115.341" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_4022_34952" x1="58.1852" y1="68.0606" x2="74.3568" y2="75.8137" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint3_linear_4022_34952" x1="121.514" y1="92.6087" x2="129.116" y2="100.813" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint4_linear_4022_34952" x1="13.4722" y1="13.9175" x2="21.3651" y2="15.1674" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint5_linear_4022_34952" x1="58.1852" y1="108.855" x2="66.0341" y2="118.576" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint6_linear_4022_34952" x1="112.159" y1="116.273" x2="114.483" y2="123.711" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint7_linear_4022_34952" x1="18.6713" y1="31.3351" x2="23.2613" y2="34.4857" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.25"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
@@ -36,7 +36,7 @@ class BaseErrorView: BaseView {
     ) {
         self.errorImage = errorImage
         self.errorMessage = errorMessage
-        self.buttonTitle = buttonText
+        self.buttonTitle = buttonTitle
         
         super.init(frame: .zero)
     }

--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
@@ -1,0 +1,108 @@
+//
+//  BaseNetworkErrorView.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/20/25.
+//
+
+import UIKit
+
+class BaseErrorView: BaseView {
+    
+    // MARK: - Datas
+    
+    private let errorImage: UIImage
+    
+    private let errorMessage: String
+    
+    private let buttonTitle: String
+    
+    
+    // MARK: - UI Properties
+    
+    private let errorImageView = UIImageView()
+    
+    private let descriptionLabel = UILabel()
+    
+    let confirmButton = UIButton()
+    
+    
+    // MARK: - Initializer
+    
+    init(
+        errorImage: UIImage = .icError1140,
+        errorMessage: String,
+        buttonTitle: String
+    ) {
+        self.errorImage = errorImage
+        self.errorMessage = errorMessage
+        self.buttonTitle = buttonText
+        
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - UI Setting Methods
+    
+    override func setStyle() {
+        super.setStyle()
+        
+        errorImageView.do {
+            $0.image = errorImage
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        descriptionLabel.do {
+            $0.setLabel(text: errorMessage,
+                        style: .s1,
+                        color: .gray4)
+        }
+        
+        confirmButton.do {
+            var config = UIButton.Configuration.filled()
+            config.attributedTitle = AttributedString(
+                buttonTitle.ACStyle(.h7)
+            
+            )
+            config.baseBackgroundColor = .org1
+            config.background.cornerRadius = 6
+            config.contentInsets = .init(top: 13, leading: 16, bottom: 13, trailing: 16)
+            $0.configuration = config
+        }
+    }
+    
+    override func setHierarchy() {
+        super.setHierarchy()
+        
+        self.addSubviews(
+            errorImageView,
+            descriptionLabel,
+            confirmButton
+        )
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        
+        errorImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(100 * ScreenUtils.heightRatio)
+            $0.size.equalTo(ScreenUtils.widthRatio*140)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(errorImageView.snp.bottom).offset(24)
+            $0.centerX.equalTo(errorImageView)
+        }
+        
+        confirmButton.snp.makeConstraints{
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
+            $0.centerX.equalToSuperview()
+        }
+    }
+    
+}


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #61 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
1. 재사용성을 높이기 위해 
에러 이미지, 메시지, 버튼 타이틀을 입력받는 에러 뷰를 구현했습니다.

이니셜라이저는 다음과 같으며, 이미지의 경우, 기본으로 ic_error_1을 넣어두었습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/469a5497-6473-466f-acf5-11be3c2c0adc" />


2. 네트워크 에러의 경우 StringLiterals에 다음과 같이 넣어두었습니다.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/4c0c70ef-6299-4264-9768-816445c63c45" />



## 🚨 사용 방법

1. 인스턴스 생성
```swift
let errorView1 = BaseErrorView(
    errorMessage: StringLiterals.ErrorMessages.checkInternet,
    buttonTitle: StringLiterals.ErrorMessages.reload
)
 // 다른 이미지 사용하고 싶을 경우 파라미터에 입력 가능
let errorView2 = BaseErrorView(
    errorImage: .imgEx1,
    errorMessage: StringLiterals.Error.checkInternet,
    buttonTitle: StringLiterals.Error.reload
)
```

2. 버튼 액션 추가
```swift
errorView.confirmButton.addTarget(<#T##Any?#>, action: <#T##Selector#>, for: <#T##UIControl.Event#>)
```

## 📸 스크린샷

https://github.com/user-attachments/assets/65127efe-a203-4fd2-97f7-963bf97f743f


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #61
