### PR TITLE
[FIX] 1차 QA 대응 - 유림 (#67)

### DIFF
--- a/ACON-iOS/ACON-iOS/Global/UIComponents/LoginModal/View/LoginModalViewController.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/LoginModal/View/LoginModalViewController.swift
@@ -116,14 +116,37 @@ extension LoginModalViewController {
             guard let self = self else { return }
             self.onSuccessLogin?(onSuccess)
             self.dismiss(animated: true)
-            onSuccess ? ACToastController.show(StringLiterals.LoginModal.successLogin, bottomInset: 112, delayTime: 1) { return } : showLoginFailAlert()
+            
+            let hasVerifiedArea = loginViewModel.hasVerifiedArea
+            if onSuccess && hasVerifiedArea {
+                print("🥑onSuccess && hasVerifiedArea")
+                ACToastController.show(
+                    StringLiterals.LoginModal.successLogin,
+                    bottomInset: 112,
+                    delayTime: 1
+                ) { return }
+                switchRootToTabBar()
+            } else if onSuccess && !hasVerifiedArea {
+                print("🥑onSuccess && !hasVerifiedArea")
+                navigateToLocalVerificationVC()
+            } else {
+                showLoginFailAlert()
+            }
+        }
+    }
+    
+    func switchRootToTabBar() {
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = ACTabBarController()
         }
     }
     
     func navigateToLocalVerificationVC() {
         let vm = LocalVerificationViewModel(flowType: .onboarding)
         let vc = LocalVerificationViewController(viewModel: vm)
-        self.navigationController?.pushViewController(vc, animated: false)
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: vc)
+        }
     }
     
     func showLoginFailAlert() {

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalMapViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalMapViewController.swift
@@ -93,7 +93,8 @@ private extension LocalMapViewController {
             let areaName: String = self?.localVerificationViewModel.localAreaName.value ?? ""
             
             print("onSuccessPostLocalArea: \(onSuccess)")
-
+            UserDefaults.standard.set(onSuccess,
+                                      forKey: StringLiterals.UserDefaults.hasVerifiedArea)
             if onSuccess {
                 switch flowType {
                 case .onboarding:

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/Type/ProfileValidMessageType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/Type/ProfileValidMessageType.swift
@@ -10,7 +10,7 @@ import Foundation
 enum ProfileValidMessageType {
     
     case none
-    case nicknameMissing, invalidChar, nicknameTaken, nicknameOK
+    case nicknameMissing, invalidSymbolAndLang, invalidSymbol, invalidLanguage ,nicknameTaken, nicknameOK
     case invalidDate
     case areaMissing
     
@@ -18,10 +18,10 @@ enum ProfileValidMessageType {
         switch self {
         case .none: return [""]
         case .nicknameMissing: return ["닉네임을 입력해주세요"]
-        case .invalidChar: return [
-            "._ 이외의 특수기호는 사용할 수 없어요",
-            "한국어, 영어 이외의 언어는 사용할 수 없어요"
-        ]
+        case .invalidSymbolAndLang: return ["._ 이외의 특수기호는 사용할 수 없어요",
+                                            "한국어, 영어 이외의 언어는 사용할 수 없어요"]
+        case .invalidSymbol: return ["._ 이외의 특수기호는 사용할 수 없어요"]
+        case .invalidLanguage: return ["한국어, 영어 이외의 언어는 사용할 수 없어요"]
         case .nicknameTaken: return ["이미 사용중인 닉네임이에요"]
         case .nicknameOK: return ["사용할 수 있는 닉네임이에요"]
         case .invalidDate: return ["정확한 생년월일을 적어주세요"]

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileEditValidMessageView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileEditValidMessageView.swift
@@ -82,7 +82,7 @@ class ProfileEditValidMessageView: BaseView {
             hideFirstLine(true)
             hideSecondLine(true)
             
-        case .nicknameMissing, .nicknameTaken, .invalidDate, .areaMissing:
+        case .nicknameMissing, .nicknameTaken, .invalidDate, .areaMissing, .invalidSymbol, .invalidLanguage:
             guard type.texts.count == 1 else { print(idxErrMsg); return }
             hideFirstLine(false)
             hideSecondLine(true)
@@ -96,7 +96,7 @@ class ProfileEditValidMessageView: BaseView {
             firstIcon.image = .icLocalCheckMark20
             firstLine.setLabel(text: type.texts[0], style: .s2, color: .blue1)
         
-        case .invalidChar:
+        case .invalidSymbolAndLang:
             guard type.texts.count == 2 else { print(idxErrMsg); return }
             hideFirstLine(false)
             hideSecondLine(false)

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileEditViewController.swift
@@ -403,8 +403,12 @@ private extension ProfileEditViewController {
         } else {
             // NOTE: FAIL -> 입력 X
             if byte <= viewModel.maxNicknameLength {
-                // NOTE: 16자 미만인 경우 유효성 메시지 2초간 띄움
-                profileEditView.setNicknameValidMessage(.invalidChar)
+                // NOTE: 언어인지 특수문자인지 판별
+                if string.unicodeScalars.allSatisfy({ $0.properties.isAlphabetic }) {
+                    profileEditView.setNicknameValidMessage(.invalidLanguage)
+                } else {
+                    profileEditView.setNicknameValidMessage(.invalidSymbol)
+                }
                 textField.layer.borderColor = UIColor.red1.cgColor
                 validMsgHideDebouncer.call { [weak self] in
                     guard let self = self else { return }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -91,7 +91,7 @@ class ProfileViewModel: Serviceable {
                 if error.code == 40901 {
                     self?.nicknameValidityMessageType = .nicknameTaken
                 } else if error.code == 40051 {
-                    self?.nicknameValidityMessageType = .invalidChar
+                    self?.nicknameValidityMessageType = .invalidSymbolAndLang
                 }
                 self?.onGetNicknameValiditySuccess.value = false
             default:

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -35,9 +35,9 @@ class SpotListViewModel: Serviceable {
     
     var walkingTime: SpotType.WalkingDistanceType = .defaultValue
     
-    var restaurantPrice: SpotType.RestaurantPriceType = .defaultValue // TODO: 옵셔널로 변경
+    var restaurantPrice: SpotType.RestaurantPriceType? = nil
     
-    var cafePrice: SpotType.CafePriceType = .defaultValue // TODO: 옵셔널로 변경
+    var cafePrice: SpotType.CafePriceType? = nil
     
     
     // MARK: - Methods
@@ -59,8 +59,8 @@ class SpotListViewModel: Serviceable {
         spotType.value = nil
         filterList.removeAll()
         walkingTime = .defaultValue
-        restaurantPrice = .defaultValue
-        cafePrice = .defaultValue
+        restaurantPrice = nil
+        cafePrice = nil
     }
     
 }
@@ -105,7 +105,7 @@ extension SpotListViewModel {
                 spotType: spotType.value?.serverKey,
                 filterList: filterList.isEmpty ? nil : filterListDTO,
                 walkingTime: walkingTime.serverKey,
-                priceRange: spotType.value == .restaurant ? restaurantPrice.serverKey : cafePrice.serverKey
+                priceRange: spotType.value == .restaurant ? restaurantPrice?.serverKey : cafePrice?.serverKey
             )
         )
         

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotType.swift
@@ -200,7 +200,7 @@ enum SpotType {
         
         case fiveThousand, tenThousand, thirtyThousand, fiftyThousand, aboveFiftyThousand
         
-        static let defaultValue: Self = .aboveFiftyThousand
+        static let defaultValue: Self = .tenThousand
         
         var text: String {
             switch self {
@@ -228,7 +228,7 @@ enum SpotType {
         
         case threeTousand, fiveThousand, aboveTenThousand
         
-        static let defaultValue: Self = .aboveTenThousand
+        static let defaultValue: Self = .fiveThousand
         
         var text: String {
             switch self {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -78,11 +78,11 @@ class SpotListFilterView: GlassmorphismView {
     
     let restaurantPriceSlider = CustomSlider(
         indicators: SpotType.RestaurantPriceType.allCases.map { return $0.text },
-        startIndex: 4)
+        startIndex: 1)
     
     let cafePriceSlider = CustomSlider(
         indicators: SpotType.CafePriceType.allCases.map { return $0.text },
-        startIndex: 2)
+        startIndex: 1)
     
     
     // MARK: - Lifecycle

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -233,8 +233,8 @@ private extension SpotListFilterViewController {
         
         // NOTE: 슬라이더 세팅
         let walkingTimeIndex = SpotType.WalkingDistanceType.allCases.firstIndex(of: viewModel.walkingTime) ?? 2
-        let restaurantPriceIndex = SpotType.RestaurantPriceType.allCases.firstIndex(of: viewModel.restaurantPrice) ?? 1
-        let cafePriceIndex = SpotType.CafePriceType.allCases.firstIndex(of: viewModel.cafePrice) ?? 2
+        let restaurantPriceIndex = SpotType.RestaurantPriceType.allCases.firstIndex(of: viewModel.restaurantPrice ?? .defaultValue) ?? 1
+        let cafePriceIndex = SpotType.CafePriceType.allCases.firstIndex(of: viewModel.cafePrice ?? .defaultValue) ?? 2
         
         spotListFilterView.walkingSlider.moveThumbPosition(to: walkingTimeIndex)
         spotListFilterView.restaurantPriceSlider.moveThumbPosition(to: restaurantPriceIndex)


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #67 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
**1.  바텀시트로 로그인 시 화면 이동 오류 해결**
  - 원인: 로직을 LoginVC에만 설정해둔 탓...
  - 해결: 로그인 성공 시 `hasVerifiedArea` 확인 후, [동네 인증 OR 탭바]로 이동하는 로직을 (LoginModalVC)에도 설정

**2. 자동로그인 시 동네인증으로 이동하는 오류 해결**
  - 원인: UserDefaults의 `hasVerifiedArea`가 로그인 직후에만 set됨
  - 해결: 동네인증 success 시에도 `hasVerifiedArea`를 set하도록 수정

**3. 가격 필터 슬라이더의 기본 위치가 1번 인덱스가 아닌 4번 인덱스인 문제 해결**
  - 원인: 앱잼 때 장소리스트 서버통신에 문제가 있었어서 임시방편으로 가격필터를 최댓값으로 해놨었음
  - 해결: 슬라이더 기본값 수정했고, 서버 통신도 제대로 되는 것 확인함.

**4. 닉네임에 특수기호 입력했을 때 [._만 가능, 한/영만 가능] 모두 뜨는 문제 해결**
  - 원인: 모두 떠야하는 줄 알았음..
  - 해결: 특수기호 입력 시 -> [". _만 가능"] // 기타 언어 입력 시 -> ["한/영만 가능"] 띄움
  - 참고: [._만 가능, 한/영만 가능]이 둘 다 뜨는 경우는 다음과 같음
    - 중국어 입력할 때 qwerty자판 또는 손글씨로 중국어 만드는 케이스, 
    - 혹시나 서버에서 40051 에러를 보낼 때 바인딩을 위함.


## 📸 스크린샷
닉네임 텍스트필드 녹화본

https://github.com/user-attachments/assets/c6bf965b-b551-4747-960c-3c61512085bf


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #67 
