### PR TITLE
[HOTFIX] 탈퇴 안 되는 에러 수정 (#74)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseView.swift
@@ -50,7 +50,7 @@ extension BaseView {
             $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*4)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(ScreenUtils.heightRatio*36)
-            $0.height.equalTo(ScreenUtils.heightRatio*3)
+            $0.height.equalTo(ScreenUtils.heightRatio*5)
         }
 
         handlerImageView.do {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/Cell/WithdrawalTableViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/Cell/WithdrawalTableViewCell.swift
@@ -38,14 +38,6 @@ final class WithdrawalTableViewCell: BaseTableViewCell {
             $0.clipsToBounds = true
             $0.contentMode = .scaleAspectFill
         }
-        
-        titleLabel.do {
-            $0.setLabel(text: "",
-                        style: .s1,
-                        alignment: .center,
-                        numberOfLines: 0)
-            $0.textColor = .acWhite
-        }
     }
     
     override func setHierarchy() {
@@ -75,7 +67,10 @@ final class WithdrawalTableViewCell: BaseTableViewCell {
     }
     
     func checkConfigure(name: String, isSelected: Bool) {
-        titleLabel.text = name
+        titleLabel.setLabel(text: name,
+                    style: .s1,
+                    alignment: .center,
+                    numberOfLines: 0)
         if isSelected {
             withdrawalImageView.image = UIImage(named: "fillCircle")
         } else {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
@@ -30,6 +30,8 @@ final class WithdrawalConfirmationView: GlassmorphismView {
     override func setStyle() {
         super.setStyle()
         
+        self.setHandlerImageView()
+        
         iconImageView.do {
             $0.image = UIImage(named: "img_empty_search") 
             $0.contentMode = .scaleAspectFit

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
@@ -33,7 +33,7 @@ final class WithdrawalConfirmationView: GlassmorphismView {
         self.setHandlerImageView()
         
         iconImageView.do {
-            $0.image = UIImage(named: "img_empty_search") 
+            $0.image = .imgEmptySearch
             $0.contentMode = .scaleAspectFit
         }
         

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
@@ -54,18 +54,14 @@ final class WithdrawalConfirmationView: GlassmorphismView {
         }
         
         cancelButton.do {
-            $0.setTitle(StringLiterals.WithdrawalConfirmation.cancelButtonTitle, for: .normal)
             $0.backgroundColor = .gray5
-            $0.setTitleColor(.white, for: .normal)
-            $0.titleLabel?.font = ACFontStyleType.h7.font
+            $0.setAttributedTitle(text: StringLiterals.WithdrawalConfirmation.cancelButtonTitle, style: .h7)
             $0.layer.cornerRadius = 6
         }
         
         confirmButton.do {
-            $0.setTitle(StringLiterals.WithdrawalConfirmation.confirmButtonTitle, for: .normal)
             $0.backgroundColor = .org1
-            $0.setTitleColor(.white, for: .normal)
-            $0.titleLabel?.font = ACFontStyleType.h7.font
+            $0.setAttributedTitle(text: StringLiterals.WithdrawalConfirmation.confirmButtonTitle, style: .h7)
             $0.layer.cornerRadius = 6
         }
         

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationView.swift
@@ -68,9 +68,8 @@ final class WithdrawalConfirmationView: GlassmorphismView {
         }
         
         closeButton.do {
-            $0.setImage(UIImage(systemName: "icX"), for: .normal)
-            $0.contentMode = .scaleAspectFit
-            $0.tintColor = .white
+            $0.setImage(.icX, for: .normal)
+            $0.tintColor = .acWhite
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
@@ -24,11 +24,34 @@ final class WithdrawalConfirmationViewController: BaseViewController {
         super.viewDidLoad()
         
         setAction()
+        bindViewModel()
     }
     
 }
 
-extension WithdrawalConfirmationViewController{
+
+// MARK: - bind VM
+
+extension WithdrawalConfirmationViewController {
+    
+    func bindViewModel() {
+        viewModel?.onSuccessWithdrawal.bind { [weak self] onSuccess in
+            guard let self = self,
+                  let onSuccess = onSuccess else { return }
+            
+            if onSuccess {
+                if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                    sceneDelegate.window?.rootViewController = SplashViewController()
+                }
+            } else {
+                self.showDefaultAlert(title: "탈퇴 실패", message: "탈퇴에 실패했습니다.")
+            }
+        }
+    }
+    
+}
+
+extension WithdrawalConfirmationViewController {
     
     private func setAction() {
         confirmationView.cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
@@ -41,12 +64,7 @@ extension WithdrawalConfirmationViewController{
     }
     
     @objc private func confirmButtonTapped() {
-
         viewModel?.withdrawalAPI()
-        
-        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.window?.rootViewController = SplashViewController()
-        }
     }
     
     @objc private func closeButtonTapped() {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
@@ -51,6 +51,9 @@ extension WithdrawalConfirmationViewController {
     
 }
 
+
+// MARK: - setAction
+
 extension WithdrawalConfirmationViewController {
     
     private func setAction() {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
@@ -44,9 +44,9 @@ extension WithdrawalConfirmationViewController{
 
         viewModel?.withdrawalAPI()
         
-        let mainVC = SplashViewController()
-        mainVC.modalPresentationStyle = .fullScreen
-        self.present(mainVC, animated: true)
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = SplashViewController()
+        }
     }
     
     @objc private func closeButtonTapped() {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalViewController.swift
@@ -141,7 +141,7 @@ extension WithdrawalViewController {
     
     private func presentWithdrawalSheet() {
         let sheetVC = WithdrawalConfirmationViewController()
-        
+        sheetVC.viewModel = viewModel
         sheetVC.setSheetLayout(detent: .short)
         sheetVC.isModalInPresentation = true
         

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
@@ -41,7 +41,6 @@ final class WithdrawalViewModel {
         }
     }
     
-    // TODO: make api
     func withdrawalAPI() {
         let refreshToken = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.refreshToken) ?? ""
         
@@ -49,24 +48,19 @@ final class WithdrawalViewModel {
             print("⚠️")
             return
         }
-        
-        let withdrawalRequest = WithdrawalRequest(reason: reasonText, refreshToken: refreshToken)
-              print("📤 Withdrawal Request Body: \(withdrawalRequest)") // NOTE: DEGUB
-        
+
         ACService.shared.withdrawalService.postWithdrawal(
             WithdrawalRequest(reason: reasonText, refreshToken: refreshToken)) { result in
-                switch result {
-                case .success:
-                    print("⚙️WithDrawal 成功")
-                    for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                        UserDefaults.standard.removeObject(forKey: key.description)
-                    }
-                    self.onSuccessWithdrawal.value = true
-                default:
-                    self.onSuccessWithdrawal.value = false
-                    print("⚙️Logout Failed")
+            switch result {
+            case .success:
+                for key in UserDefaults.standard.dictionaryRepresentation().keys {
+                    UserDefaults.standard.removeObject(forKey: key.description)
                 }
+                self.onSuccessWithdrawal.value = true
+            default:
+                self.onSuccessWithdrawal.value = false
             }
+        }
     }
 }
 

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
@@ -14,6 +14,7 @@ final class WithdrawalViewModel {
     var shouldDismissKeyboard: ObservablePattern<Bool> = ObservablePattern(false)
     var ectOption: ObservablePattern<Bool> = ObservablePattern(false)
     
+    let onSuccessWithdrawal: ObservablePattern<Bool> = ObservablePattern(nil)
     
     func updateSelectedOption(_ option: String?) {
         selectedOption.value = option
@@ -60,8 +61,9 @@ final class WithdrawalViewModel {
                     for key in UserDefaults.standard.dictionaryRepresentation().keys {
                         UserDefaults.standard.removeObject(forKey: key.description)
                     }
-                    
+                    self.onSuccessWithdrawal.value = true
                 default:
+                    self.onSuccessWithdrawal.value = false
                     print("⚙️Logout Failed")
                 }
             }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #74

## 🥔 **작업 내용**
탈퇴가 안 되는 에러를 수정했습니다.
수정하면서 탈퇴 관련 코드들 중 잘못 작성된 코드 수정 및 정돈했습니다.

## 🚨 참고 사항
처음에 발견한 건 (위치 접근 권한 거부 상태에서) 탈퇴 API 호출 자체가 안 되는 문제였는데, 확인해보니 뷰모델 바인딩을 통해 서버 통신을 진행하지 않아 서버 통신이 완료되기 전에 스플래시로 돌아가는 코드가 호출되어 생기는 문제였습니다. 이를 뷰모델 바인딩으로 해결하였습니다.

더불어, 재현오빠 코드 중 잘못된 부분들을 다 고쳐두었습니다. 특히 상황에 맞는 1️⃣ 화면 전환 2️⃣ 서버 통신 시 뷰모델 바인딩 3️⃣ Base 파일들 및 extension에 이미 구현되어있는 로직 (이건 #71 에서 리팩한 부분도 함께 봐주세요) 을 확실히 익혀주시면 좋을 것 같습니다. 이 피알을 꼼꼼하게 뜯어보고, 궁금한 거 언제든 물어봐주세요 ! @Ohjackson 

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #74
