### PR TITLE
[FEAT] 법정동 API 연결, 서비스 불가 지역 대응 (#76)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		15AA6D132D68AAB1008021C6 /* GetDongResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */; };
 		15AA6D152D68AC09008021C6 /* GetDongRequestQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */; };
 		15AA6D172D68B4EF008021C6 /* SpotListErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */; };
+		15AA6D1A2D68C4AD008021C6 /* ReviewVerificationErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D192D68C4AD008021C6 /* ReviewVerificationErrorType.swift */; };
 		15BFF8B92D665BAD00909C4F /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 15BFF8B52D665A5B00909C4F /* Debug.xcconfig */; };
 		15BFF8BA2D665BAD00909C4F /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 15BFF8B62D665A5B00909C4F /* Release.xcconfig */; };
 		15C0ED522D429F7400C9ED83 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C0ED512D429F7400C9ED83 /* SkeletonView.swift */; };
@@ -294,6 +295,7 @@
 		15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongResponse.swift; sourceTree = "<group>"; };
 		15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongRequestQuery.swift; sourceTree = "<group>"; };
 		15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListErrorType.swift; sourceTree = "<group>"; };
+		15AA6D192D68C4AD008021C6 /* ReviewVerificationErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewVerificationErrorType.swift; sourceTree = "<group>"; };
 		15BFF8B52D665A5B00909C4F /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		15BFF8B62D665A5B00909C4F /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		15C0ED512D429F7400C9ED83 /* SkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
@@ -699,6 +701,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		15AA6D182D68C494008021C6 /* Type */ = {
+			isa = PBXGroup;
+			children = (
+				15AA6D192D68C4AD008021C6 /* ReviewVerificationErrorType.swift */,
+			);
+			path = Type;
+			sourceTree = "<group>";
+		};
 		15CD256C2D3D794300320006 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -820,6 +830,7 @@
 		74220DD12D34361E000684BF /* Upload */ = {
 			isa = PBXGroup;
 			children = (
+				15AA6D182D68C494008021C6 /* Type */,
 				745C7E0E2D35A53E0074DBDB /* Model */,
 				745C7E132D35AEA70074DBDB /* ViewModel */,
 				74220DD22D34362C000684BF /* View */,
@@ -1865,6 +1876,7 @@
 				7462D0252D4262F300580464 /* AuthManager.swift in Sources */,
 				74C914D12D64DBBB00BC13E1 /* ImageType.swift in Sources */,
 				74BF92152D391FFE00B923E3 /* LocalVerificationView.swift in Sources */,
+				15AA6D1A2D68C4AD008021C6 /* ReviewVerificationErrorType.swift in Sources */,
 				741429652D5D470200B69528 /* SettingViewModel.swift in Sources */,
 				74BF92042D3861A600B923E3 /* SpotDetailViewController.swift in Sources */,
 				15CD256B2D3D61F500320006 /* GlassmorphismView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */; };
 		1558BADE2D31AB6C00ECDEF8 /* SpotListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */; };
 		156AA7242D6504F1005B8DCE /* GetVerifiedAreaListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156AA7232D6504F1005B8DCE /* GetVerifiedAreaListResponse.swift */; };
-		156AA72A2D6510E1005B8DCE /* GetNicknameValidityRequestQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156AA7292D6510E1005B8DCE /* GetNicknameValidityRequestQuery.swift */; };
+		156AA72A2D6510E1005B8DCE /* GetNicknameValidityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156AA7292D6510E1005B8DCE /* GetNicknameValidityRequest.swift */; };
 		156D925C2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156D925B2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift */; };
 		156D925E2D65375B0037F8F1 /* CustomAlertTitleAndButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156D925D2D65375B0037F8F1 /* CustomAlertTitleAndButtonsViewController.swift */; };
 		156D92602D6570A90037F8F1 /* PatchProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156D925F2D6570A90037F8F1 /* PatchProfileRequest.swift */; };
@@ -47,7 +47,7 @@
 		15A48BFC2D574BB9003C2421 /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A48BFB2D574BB9003C2421 /* ProfileEditViewController.swift */; };
 		15A48BFE2D57546A003C2421 /* ProfileImageEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A48BFD2D57546A003C2421 /* ProfileImageEditButton.swift */; };
 		15AA6D132D68AAB1008021C6 /* GetDongResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */; };
-		15AA6D152D68AC09008021C6 /* GetDongRequestQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */; };
+		15AA6D152D68AC09008021C6 /* GetDongRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D142D68AC09008021C6 /* GetDongRequest.swift */; };
 		15AA6D172D68B4EF008021C6 /* SpotListErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */; };
 		15AA6D1A2D68C4AD008021C6 /* ReviewVerificationErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D192D68C4AD008021C6 /* ReviewVerificationErrorType.swift */; };
 		15BFF8B92D665BAD00909C4F /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 15BFF8B52D665A5B00909C4F /* Debug.xcconfig */; };
@@ -276,7 +276,7 @@
 		1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarItemType.swift; sourceTree = "<group>"; };
 		1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListViewController.swift; sourceTree = "<group>"; };
 		156AA7232D6504F1005B8DCE /* GetVerifiedAreaListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVerifiedAreaListResponse.swift; sourceTree = "<group>"; };
-		156AA7292D6510E1005B8DCE /* GetNicknameValidityRequestQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetNicknameValidityRequestQuery.swift; sourceTree = "<group>"; };
+		156AA7292D6510E1005B8DCE /* GetNicknameValidityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetNicknameValidityRequest.swift; sourceTree = "<group>"; };
 		156D925B2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertTitleAndButtonsView.swift; sourceTree = "<group>"; };
 		156D925D2D65375B0037F8F1 /* CustomAlertTitleAndButtonsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertTitleAndButtonsViewController.swift; sourceTree = "<group>"; };
 		156D925F2D6570A90037F8F1 /* PatchProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchProfileRequest.swift; sourceTree = "<group>"; };
@@ -293,7 +293,7 @@
 		15A48BFB2D574BB9003C2421 /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		15A48BFD2D57546A003C2421 /* ProfileImageEditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageEditButton.swift; sourceTree = "<group>"; };
 		15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongResponse.swift; sourceTree = "<group>"; };
-		15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongRequestQuery.swift; sourceTree = "<group>"; };
+		15AA6D142D68AC09008021C6 /* GetDongRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongRequest.swift; sourceTree = "<group>"; };
 		15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListErrorType.swift; sourceTree = "<group>"; };
 		15AA6D192D68C4AD008021C6 /* ReviewVerificationErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewVerificationErrorType.swift; sourceTree = "<group>"; };
 		15BFF8B52D665A5B00909C4F /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -530,7 +530,7 @@
 			isa = PBXGroup;
 			children = (
 				151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */,
-				156AA7292D6510E1005B8DCE /* GetNicknameValidityRequestQuery.swift */,
+				156AA7292D6510E1005B8DCE /* GetNicknameValidityRequest.swift */,
 				156D925F2D6570A90037F8F1 /* PatchProfileRequest.swift */,
 			);
 			path = DTO;
@@ -734,7 +734,7 @@
 			children = (
 				15CD25772D3FE31400320006 /* PostSpotListRequest.swift */,
 				15CD257B2D3FF13F00320006 /* PostSpotListResponse.swift */,
-				15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */,
+				15AA6D142D68AC09008021C6 /* GetDongRequest.swift */,
 				15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */,
 			);
 			path = DTO;
@@ -1776,7 +1776,7 @@
 				747F4FBF2D3D9D44003DECBF /* SplashView.swift in Sources */,
 				74C914D32D64E01C00BC13E1 /* PutImageToPresignedURLRequest.swift in Sources */,
 				7462616F2D3EA48300A4E84F /* GetSearchKeywordResponse.swift in Sources */,
-				156AA72A2D6510E1005B8DCE /* GetNicknameValidityRequestQuery.swift in Sources */,
+				156AA72A2D6510E1005B8DCE /* GetNicknameValidityRequest.swift in Sources */,
 				74D297F82D63467900DDEE31 /* ImageService.swift in Sources */,
 				15A147212D5B256D003793EE /* LocalVerificationFlowType.swift in Sources */,
 				D6E816AA2D624DDB001E4EBF /* BaseTabelViewCell.swift in Sources */,
@@ -1866,7 +1866,7 @@
 				15CD257E2D3FF4F200320006 /* SpotListTargetType.swift in Sources */,
 				156D925C2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift in Sources */,
 				74BF92132D391FFE00B923E3 /* LocalVerificationFinishedViewController.swift in Sources */,
-				15AA6D152D68AC09008021C6 /* GetDongRequestQuery.swift in Sources */,
+				15AA6D152D68AC09008021C6 /* GetDongRequest.swift in Sources */,
 				746F15B72D3E2083003EA031 /* PostLocalAreaRequest.swift in Sources */,
 				74BF92142D391FFE00B923E3 /* LocalMapView.swift in Sources */,
 				D696F1B22D3A7E3400CCD5FF /* CustomAlertView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		15A48BFA2D574BA5003C2421 /* ProfileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A48BF92D574BA5003C2421 /* ProfileEditView.swift */; };
 		15A48BFC2D574BB9003C2421 /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A48BFB2D574BB9003C2421 /* ProfileEditViewController.swift */; };
 		15A48BFE2D57546A003C2421 /* ProfileImageEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A48BFD2D57546A003C2421 /* ProfileImageEditButton.swift */; };
+		15AA6D132D68AAB1008021C6 /* GetDongResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */; };
+		15AA6D152D68AC09008021C6 /* GetDongRequestQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */; };
+		15AA6D172D68B4EF008021C6 /* SpotListErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */; };
 		15BFF8B92D665BAD00909C4F /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 15BFF8B52D665A5B00909C4F /* Debug.xcconfig */; };
 		15BFF8BA2D665BAD00909C4F /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 15BFF8B62D665A5B00909C4F /* Release.xcconfig */; };
 		15C0ED522D429F7400C9ED83 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C0ED512D429F7400C9ED83 /* SkeletonView.swift */; };
@@ -71,8 +74,8 @@
 		15CF62C72D57DE680000A10F /* ProfileEditTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CF62C62D57DE680000A10F /* ProfileEditTextField.swift */; };
 		15D122292D58BD0200E79866 /* DayOfMonthType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D122282D58BD0200E79866 /* DayOfMonthType.swift */; };
 		15DC053F2D623DD400B752DD /* PostLogoutRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DC053E2D623DD400B752DD /* PostLogoutRequest.swift */; };
-		15F45F862D66877200BD6B9C /* LoadingAnimatedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F45F852D66877200BD6B9C /* LoadingAnimatedButton.swift */; };
 		15F45F842D6664C900BD6B9C /* BaseErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F45F832D6664C900BD6B9C /* BaseErrorView.swift */; };
+		15F45F862D66877200BD6B9C /* LoadingAnimatedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F45F852D66877200BD6B9C /* LoadingAnimatedButton.swift */; };
 		4C6B2F332D65A15D0089BCB6 /* WithdrawalTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F312D65A15D0089BCB6 /* WithdrawalTargetType.swift */; };
 		4C6B2F342D65A15D0089BCB6 /* WithdrawalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F302D65A15D0089BCB6 /* WithdrawalService.swift */; };
 		4C6B2F352D65A15D0089BCB6 /* WithdrawalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B2F2E2D65A15D0089BCB6 /* WithdrawalRequest.swift */; };
@@ -288,6 +291,9 @@
 		15A48BF92D574BA5003C2421 /* ProfileEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
 		15A48BFB2D574BB9003C2421 /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		15A48BFD2D57546A003C2421 /* ProfileImageEditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageEditButton.swift; sourceTree = "<group>"; };
+		15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongResponse.swift; sourceTree = "<group>"; };
+		15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDongRequestQuery.swift; sourceTree = "<group>"; };
+		15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListErrorType.swift; sourceTree = "<group>"; };
 		15BFF8B52D665A5B00909C4F /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		15BFF8B62D665A5B00909C4F /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		15C0ED512D429F7400C9ED83 /* SkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
@@ -313,8 +319,8 @@
 		15CF62C62D57DE680000A10F /* ProfileEditTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditTextField.swift; sourceTree = "<group>"; };
 		15D122282D58BD0200E79866 /* DayOfMonthType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfMonthType.swift; sourceTree = "<group>"; };
 		15DC053E2D623DD400B752DD /* PostLogoutRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLogoutRequest.swift; sourceTree = "<group>"; };
-		15F45F852D66877200BD6B9C /* LoadingAnimatedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingAnimatedButton.swift; sourceTree = "<group>"; };
 		15F45F832D6664C900BD6B9C /* BaseErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorView.swift; sourceTree = "<group>"; };
+		15F45F852D66877200BD6B9C /* LoadingAnimatedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingAnimatedButton.swift; sourceTree = "<group>"; };
 		4C6B2F2E2D65A15D0089BCB6 /* WithdrawalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalRequest.swift; sourceTree = "<group>"; };
 		4C6B2F302D65A15D0089BCB6 /* WithdrawalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalService.swift; sourceTree = "<group>"; };
 		4C6B2F312D65A15D0089BCB6 /* WithdrawalTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalTargetType.swift; sourceTree = "<group>"; };
@@ -590,6 +596,7 @@
 			children = (
 				1547A8772D3550D900E96616 /* MatchingRateBgColorType.swift */,
 				15A3F6A52D36C49F00577E16 /* SpotListItemSizeType.swift */,
+				15AA6D162D68B4EF008021C6 /* SpotListErrorType.swift */,
 			);
 			path = Type;
 			sourceTree = "<group>";
@@ -717,6 +724,8 @@
 			children = (
 				15CD25772D3FE31400320006 /* PostSpotListRequest.swift */,
 				15CD257B2D3FF13F00320006 /* PostSpotListResponse.swift */,
+				15AA6D142D68AC09008021C6 /* GetDongRequestQuery.swift */,
+				15AA6D122D68AAB1008021C6 /* GetDongResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1841,10 +1850,12 @@
 				74BF92122D391FFE00B923E3 /* LocalMapViewController.swift in Sources */,
 				D6E8168E2D6228F5001E4EBF /* WithdrawalViewController.swift in Sources */,
 				15F45F842D6664C900BD6B9C /* BaseErrorView.swift in Sources */,
+				15AA6D132D68AAB1008021C6 /* GetDongResponse.swift in Sources */,
 				746261692D3EA33300A4E84F /* PostReviewRequest.swift in Sources */,
 				15CD257E2D3FF4F200320006 /* SpotListTargetType.swift in Sources */,
 				156D925C2D6536CF0037F8F1 /* CustomAlertTitleAndButtonsView.swift in Sources */,
 				74BF92132D391FFE00B923E3 /* LocalVerificationFinishedViewController.swift in Sources */,
+				15AA6D152D68AC09008021C6 /* GetDongRequestQuery.swift in Sources */,
 				746F15B72D3E2083003EA031 /* PostLocalAreaRequest.swift in Sources */,
 				74BF92142D391FFE00B923E3 /* LocalMapView.swift in Sources */,
 				D696F1B22D3A7E3400CCD5FF /* CustomAlertView.swift in Sources */,
@@ -1897,6 +1908,7 @@
 				748ECA6E2D3196F100BBC981 /* LoginViewController.swift in Sources */,
 				746261892D3FA29C00A4E84F /* SpotDetailTargetType.swift in Sources */,
 				D6E34C432D398B6000CEFA04 /* CustomAlertImageViewController.swift in Sources */,
+				15AA6D172D68B4EF008021C6 /* SpotListErrorType.swift in Sources */,
 				741E68952D3D38BC00DF99EF /* BaseService.swift in Sources */,
 				746F15BB2D3E2167003EA031 /* LocalVerificationTargetType.swift in Sources */,
 				D6E34C462D398B6000CEFA04 /* AlertType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -143,9 +143,13 @@ enum StringLiterals {
         
         static let footerText = "장소는 최대 6순위까지만 제공됩니다."
         
-        static let noAcorn = "앗! 일치하는 도토리 맛집이 없어요"
+        static let failedToGetAddressNavTitle = "위치 확인 실패" // TODO: 라이팅 기획과 논의
         
-        static let failedToGetAddress = "위치 확인 실패" // TODO: 라이팅 기획과 논의
+        static let emptySpotListErrorMessage = "앗! 일치하는 도토리 맛집이 없어요"
+        
+        static let unsupportedRegionNavTitle = "서비스 불가지역"
+        
+        static let unsupportedRegionErrorMessage = "앗! 서비스 지원이 불가능한 지역에 있어요"
         
     }
     

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/CustomAlert/AlertHandler.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/CustomAlert/AlertHandler.swift
@@ -22,6 +22,14 @@ class AlertHandler {
         viewController.present(customAlertImageViewController, animated: true, completion: nil)
     }
     
+    func showUnsupportedRegionImageAlert(from viewController: UIViewController) {
+        let customAlertImageViewController = CustomAlertImageViewController()
+        customAlertImageViewController.configure(with: .locationAccessFailImage)
+        customAlertImageViewController.modalPresentationStyle = .overFullScreen
+        customAlertImageViewController.modalTransitionStyle = .crossDissolve
+        viewController.present(customAlertImageViewController, animated: true, completion: nil)
+    }
+    
     
     // MARK: - 취향 분석 중단 Alert
     

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/CustomAlert/Type/AlertType.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/CustomAlert/Type/AlertType.swift
@@ -11,6 +11,7 @@ enum AlertType: CaseIterable {
     
     case stoppedPreferenceAnalysis // 온보딩 중
     case locationAccessFailImage // 이건 사진
+    case unsupportedRegion // 리뷰 - 위치 인증 실패
     case locationAccessDenied // 업로드 중
     case uploadExit // 업로드 중
     case logout
@@ -24,6 +25,8 @@ enum AlertType: CaseIterable {
             return "취향분석을 그만둘까요?"
         case .locationAccessFailImage:
             return "위치 인식 실패"
+        case .unsupportedRegion:
+            return "위치 인증 실패"
         case .locationAccessDenied:
             return "위치를 확인할 수 없습니다."
         case .uploadExit:
@@ -45,6 +48,8 @@ enum AlertType: CaseIterable {
             return "선호도 조사만이 남아있어요!\n1분 내로 빠르게 끝내실 수 있어요."
         case .locationAccessFailImage:
             return "현재 위치와 등록 장소가 오차 범위 밖에 있습니다.\n좀 더 가까이 이동해보세요."
+        case .unsupportedRegion:
+            return "현재 인증이 불가능한 지역에 있어요."
         case .locationAccessDenied:
             return "acon을 사용하기 위해서는,\n설정에서 정확한 위치 권한을 허용해주세요."
         case .uploadExit:
@@ -65,7 +70,7 @@ enum AlertType: CaseIterable {
         case .stoppedPreferenceAnalysis,
                 .uploadExit:
             return ["그만두기", "계속하기"]
-        case .locationAccessFailImage:
+        case .locationAccessFailImage, .unsupportedRegion:
             return ["확인"]
         case .locationAccessDenied, .libraryAccessDenied:
             return ["그만두기", "설정으로 가기"]

--- a/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetNicknameValidityRequest.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/DTO/GetNicknameValidityRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct GetNicknameValidityRequestQuery {
+struct GetNicknameValidityRequest {
     
     let nickname: String
     

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileService.swift
@@ -13,7 +13,7 @@ protocol ProfileServiceProtocol {
 
     func getProfile(completion: @escaping (NetworkResult<GetProfileResponse>) -> Void)
     
-    func getNicknameValidity(parameter: GetNicknameValidityRequestQuery,
+    func getNicknameValidity(parameter: GetNicknameValidityRequest,
                              completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
     
     func patchProfile(requestBody: PatchProfileRequest,
@@ -39,7 +39,7 @@ final class ProfileService: BaseService<ProfileTargetType>, ProfileServiceProtoc
         }
     }
     
-    func getNicknameValidity(parameter: GetNicknameValidityRequestQuery,
+    func getNicknameValidity(parameter: GetNicknameValidityRequest,
                              completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
         self.provider.request(.getNicknameValidity(parameter)) { result in
             switch result {

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
@@ -13,7 +13,7 @@ enum ProfileTargetType {
     
     case getProfile
     
-    case getNicknameValidity(_ parameter: GetNicknameValidityRequestQuery)
+    case getNicknameValidity(_ parameter: GetNicknameValidityRequest)
     
     case patchProfile(_ requestBody: PatchProfileRequest)
 

--- a/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongRequest.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct GetDongRequestQuery {
+struct GetDongRequest {
     
     let latitude: Double
     

--- a/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongRequestQuery.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongRequestQuery.swift
@@ -1,0 +1,16 @@
+//
+//  GetDongRequestQuery.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/21/25.
+//
+
+import Foundation
+
+struct GetDongRequestQuery {
+    
+    let latitude: Double
+    
+    let longitude: Double
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/DTO/GetDongResponse.swift
@@ -1,0 +1,14 @@
+//
+//  GetDongResponse.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/21/25.
+//
+
+import Foundation
+
+struct GetDongResponse: Decodable {
+    
+    let area: String
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotList/SpotListService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/SpotListService.swift
@@ -14,7 +14,7 @@ protocol SpotListServiceProtocol {
     func postSpotList(requestBody: PostSpotListRequest,
                       completion: @escaping (NetworkResult<PostSpotListResponse>) -> Void)
     
-    func getDong(query: GetDongRequestQuery,
+    func getDong(query: GetDongRequest,
                  completion: @escaping (NetworkResult<GetDongResponse>) -> Void)
 
 }
@@ -38,7 +38,7 @@ final class SpotListService: BaseService<SpotListTargetType>, SpotListServicePro
         }
     }
     
-    func getDong(query: GetDongRequestQuery,
+    func getDong(query: GetDongRequest,
                  completion: @escaping (NetworkResult<GetDongResponse>) -> Void) {
         self.provider.request(.getDong(query)) { result in
             switch result {

--- a/ACON-iOS/ACON-iOS/Network/SpotList/SpotListService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/SpotListService.swift
@@ -11,7 +11,11 @@ import Moya
 
 protocol SpotListServiceProtocol {
 
-    func postSpotList(requestBody: PostSpotListRequest, completion: @escaping (NetworkResult<PostSpotListResponse>) -> Void)
+    func postSpotList(requestBody: PostSpotListRequest,
+                      completion: @escaping (NetworkResult<PostSpotListResponse>) -> Void)
+    
+    func getDong(query: GetDongRequestQuery,
+                 completion: @escaping (NetworkResult<GetDongResponse>) -> Void)
 
 }
 
@@ -26,6 +30,23 @@ final class SpotListService: BaseService<SpotListTargetType>, SpotListServicePro
                     statusCode: response.statusCode,
                     data: response.data,
                     type: PostSpotListResponse.self
+                )
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+    
+    func getDong(query: GetDongRequestQuery,
+                 completion: @escaping (NetworkResult<GetDongResponse>) -> Void) {
+        self.provider.request(.getDong(query)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetDongResponse> = self.judgeStatus(
+                    statusCode: response.statusCode,
+                    data: response.data,
+                    type: GetDongResponse.self
                 )
                 completion(networkResult)
             case .failure(let errorResponse):

--- a/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
@@ -13,7 +13,7 @@ enum SpotListTargetType {
 
     case postSpotList(_ requestBody: PostSpotListRequest)
     
-    case getDong(_ query: GetDongRequestQuery)
+    case getDong(_ query: GetDongRequest)
 
 }
 

--- a/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
@@ -12,6 +12,8 @@ import Moya
 enum SpotListTargetType {
 
     case postSpotList(_ requestBody: PostSpotListRequest)
+    
+    case getDong(_ query: GetDongRequestQuery)
 
 }
 
@@ -21,6 +23,8 @@ extension SpotListTargetType: TargetType {
         switch self {
         case .postSpotList:
             return .post
+        case .getDong:
+            return .get
         }
     }
 
@@ -28,19 +32,41 @@ extension SpotListTargetType: TargetType {
         switch self {
         case .postSpotList:
             return utilPath + "spots"
+        case .getDong:
+            return utilPath + "area"
         }
     }
-
+    
+    var parameter: [String : Any]?  {
+        switch self {
+        case .getDong(let parameter):
+            return ["latitude": parameter.latitude,
+                    "longitude": parameter.longitude]
+        default:
+            return .none
+        }
+    }
+    
     var task: Task {
         switch self {
         case .postSpotList(let requestBody):
             return .requestJSONEncodable(requestBody)
+        case .getDong:
+            if let parameter = parameter {
+                return .requestParameters(parameters: parameter, encoding: URLEncoding.default)
+            } else {
+                return .requestPlain
+            }
         }
     }
 
     var headers: [String : String]? {
-        let headers = HeaderType.headerWithToken()
-        return headers
+        switch self {
+        case .postSpotList:
+            return HeaderType.headerWithToken()
+        case .getDong:
+            return HeaderType.tokenOnly()
+        }
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
@@ -76,8 +76,10 @@ extension UploadTargetType: TargetType {
     var headers: [String : String]? {
         var headers = HeaderType.noHeader
         switch self {
-        case .getSearchKeyword, .getReviewVerification:
+        case .getSearchKeyword:
             headers = HeaderType.noHeader
+        case .getReviewVerification:
+            headers = HeaderType.tokenOnly()
         case .getSearchSuggestion, .postReview, .getAcornCount:
             headers = HeaderType.headerWithToken()
         }

--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseErrorView.swift
@@ -29,7 +29,7 @@ class BaseErrorView: BaseView {
     
     // MARK: - Initializer
     
-    init(
+    init( // TODO: 삭제하고 setStyle internal 메소드 사용 (115줄)
         errorImage: UIImage = .icError1140,
         errorMessage: String,
         buttonTitle: String
@@ -103,6 +103,51 @@ class BaseErrorView: BaseView {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
         }
+    }
+    
+}
+
+
+// MARK: - Internal Methods
+
+extension BaseErrorView {
+    
+    func setStyle(errorImage: UIImage = .icError1140,
+                  errorMessage: String?,
+                  buttonTitle: String?) {
+        errorImageView.do {
+            $0.image = errorImage
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        if let errorMessage = errorMessage {
+            descriptionLabel.do {
+                $0.isHidden = false
+                $0.setLabel(text: errorMessage,
+                            style: .s1,
+                            color: .gray4)
+            }
+        } else {
+            descriptionLabel.isHidden = true
+        }
+        
+        if let buttonTitle = buttonTitle {
+            confirmButton.do {
+                var config = UIButton.Configuration.filled()
+                config.attributedTitle = AttributedString(
+                    buttonTitle.ACStyle(.h7)
+                
+                )
+                config.baseBackgroundColor = .org1
+                config.background.cornerRadius = 6
+                config.contentInsets = .init(top: 13, leading: 16, bottom: 13, trailing: 16)
+                $0.configuration = config
+                $0.isHidden = false
+            }
+        } else {
+            confirmButton.isHidden = true
+        }
+        
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -76,7 +76,7 @@ class ProfileViewModel: Serviceable {
     }
     
     func getNicknameValidity(nickname: String) {
-        let parameter = GetNicknameValidityRequestQuery(nickname: nickname)
+        let parameter = GetNicknameValidityRequest(nickname: nickname)
         
         ACService.shared.profileService.getNicknameValidity(parameter: parameter) { [weak self] response in
             switch response {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListErrorType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListErrorType.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+
+enum SpotListErrorType {
+    
+    case emptyList, unsupportedRegion
+    
+    var errorMessage: String {
+        switch self {
+        case .emptyList: return StringLiterals.SpotList.emptySpotListErrorMessage
+        case .unsupportedRegion: return StringLiterals.SpotList.unsupportedRegionErrorMessage
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListErrorType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListErrorType.swift
@@ -1,0 +1,8 @@
+//
+//  SpotListErrorType.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/21/25.
+//
+
+import Foundation

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
@@ -24,8 +24,6 @@ class SpotListView: BaseView {
     
     lazy var floatingLocationButton = FloatingButton(image: .icMyGLocation28)
     
-    private let noAcornView = UIView()
-    
     private let noAcornImageView = UIImageView()
     
     private let noAcornLabel = UILabel()
@@ -46,16 +44,11 @@ class SpotListView: BaseView {
         self.addSubviews(
             collectionView,
             skeletonView,
-            noAcornView,
             floatingButtonStack)
         
         floatingButtonStack.addArrangedSubviews(floatingLocationButton,
                                                 floatingMapButton,
                                                 floatingFilterButton)
-        
-        noAcornView.addSubviews(
-            noAcornImageView,
-            noAcornLabel)
     }
     
     override func setLayout() {
@@ -70,21 +63,6 @@ class SpotListView: BaseView {
         floatingButtonStack.snp.makeConstraints {
             $0.trailing.equalTo(self.safeAreaLayoutGuide).offset(-20)
             $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(-16)
-        }
-        
-        noAcornView.snp.makeConstraints {
-            $0.edges.equalTo(collectionView)
-        }
-        
-        noAcornImageView.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().offset(ScreenUtils.heightRatio * 180)
-            $0.size.equalTo(ScreenUtils.widthRatio * 140)
-        }
-        
-        noAcornLabel.snp.makeConstraints {
-            $0.top.equalTo(noAcornImageView.snp.bottom).offset(24)
-            $0.centerX.equalTo(noAcornImageView)
         }
         
         skeletonView.snp.makeConstraints {
@@ -102,7 +80,6 @@ class SpotListView: BaseView {
         
         setCollectionView()
         setFloatingButtonStack()
-        setNoAcornView()
     }
     
 }
@@ -131,31 +108,12 @@ private extension SpotListView {
         }
     }
     
-    func setNoAcornView() {
-        noAcornView.do {
-            $0.backgroundColor = .gray9
-            $0.isHidden = true
-        }
-        
-        noAcornImageView.image = .imgEmptySearch
-        
-        noAcornLabel.setLabel(
-            text: StringLiterals.SpotList.noAcorn,
-            style: .s1,
-            color: .gray4)
-    }
-    
 }
 
 
 // MARK: - Binding
 
 extension SpotListView {
-    
-    func hideNoAcornView(isHidden: Bool) {
-        noAcornView.isHidden = isHidden
-        print("hidenoacornview :\(isHidden)")
-    }
     
     func updateFilterButtonColor(_ isFilterSet: Bool) {
         isFilterSet
@@ -166,4 +124,5 @@ extension SpotListView {
     func hideSkeletonView(isHidden: Bool) {
         skeletonView.isHidden = isHidden
     }
+    
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -13,6 +13,8 @@ class SpotListViewController: BaseNavViewController {
     
     private let spotListView = SpotListView()
     
+    private let errorView = BaseErrorView(errorMessage: "", buttonTitle: "")
+    
     
     // MARK: - Properties
 
@@ -43,7 +45,7 @@ class SpotListViewController: BaseNavViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        contentView.addSubview(spotListView)
+        contentView.addSubviews(spotListView, errorView)
     }
     
     override func setLayout() {
@@ -52,12 +54,17 @@ class SpotListViewController: BaseNavViewController {
         spotListView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+        
+        errorView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
     
     override func setStyle() {
         super.setStyle()
         
         setGlassMorphism()
+        errorView.isHidden = true
     }
             
     private func addTarget() {
@@ -88,10 +95,12 @@ class SpotListViewController: BaseNavViewController {
 extension SpotListViewController {
     
     func bindViewModel() {
-        viewModel.onSuccessGetAddress.bind { [weak self] onSuccess in
+        viewModel.onSuccessGetDong.bind { [weak self] onSuccess in
             guard let self = self,
                   let onSuccess = onSuccess else { return }
-            self.setTitleLabelStyle(title: onSuccess ? viewModel.myAddress : StringLiterals.SpotList.failedToGetAddress)
+            if onSuccess {
+                setTitleLabelStyle(title: viewModel.currentDong)
+            }
         }
         
         viewModel.onSuccessPostSpotList.bind { [weak self] isSuccess in
@@ -102,16 +111,13 @@ extension SpotListViewController {
                     print("🥑데이터 바뀌어서 reloadData 함")
                     spotListView.collectionView.reloadData()
                     spotListView.hideSkeletonView(isHidden: true)
-                    spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
                 } else {
                     print("🥑데이터가 안 바뀌어서 reloadData 안 함")
                     let dataExists = !viewModel.spotList.isEmpty
-                    spotListView.hideNoAcornView(isHidden: dataExists)
                     spotListView.hideSkeletonView(isHidden: dataExists)
                 }
             } else {
                 print("🥑추천장소리스트 Post 실패")
-                spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
             }
             
             viewModel.hasSpotListChanged = false
@@ -122,6 +128,24 @@ extension SpotListViewController {
             spotListView.updateFilterButtonColor(isFilterSet)
             
             viewModel.onFinishRefreshingSpotList.value = true
+        }
+        
+        viewModel.showErrorView.bind { [weak self] showErrorView in
+            guard let self = self,
+                  let showErrorView = showErrorView else { return }
+            
+            if showErrorView {
+                errorView.setStyle(errorMessage: viewModel.errorType?.errorMessage,
+                                   buttonTitle: nil)
+                
+                if viewModel.errorType == .unsupportedRegion {
+                    self.setTitleLabelStyle(title: StringLiterals.SpotList.unsupportedRegionNavTitle)
+                }
+                
+                errorView.isHidden = false
+            } else {
+                errorView.isHidden = true
+            }
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -100,7 +100,12 @@ extension SpotListViewController {
                   let onSuccess = onSuccess else { return }
             if onSuccess {
                 setTitleLabelStyle(title: viewModel.currentDong)
+            } else if viewModel.errorType == .unsupportedRegion {
+                self.setTitleLabelStyle(title: StringLiterals.SpotList.unsupportedRegionNavTitle)
+            } else {
+                self.setTitleLabelStyle(title: StringLiterals.SpotList.failedToGetAddressNavTitle)
             }
+            viewModel.onSuccessGetDong.value = nil
         }
         
         viewModel.onSuccessPostSpotList.bind { [weak self] isSuccess in
@@ -137,11 +142,6 @@ extension SpotListViewController {
             if showErrorView {
                 errorView.setStyle(errorMessage: viewModel.errorType?.errorMessage,
                                    buttonTitle: nil)
-                
-                if viewModel.errorType == .unsupportedRegion {
-                    self.setTitleLabelStyle(title: StringLiterals.SpotList.unsupportedRegionNavTitle)
-                }
-                
                 errorView.isHidden = false
             } else {
                 errorView.isHidden = true

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -146,6 +146,8 @@ extension SpotListViewController {
             } else {
                 errorView.isHidden = true
             }
+            
+            viewModel.showErrorView.value = nil
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -94,6 +94,8 @@ extension SpotListViewModel {
                     if error.code == 40405 {
                         self?.errorType = .unsupportedRegion
                         self?.showErrorView.value = true
+                    } else {
+                        self?.showErrorView.value = false
                     }
                     self?.onSuccessGetDong.value = false
                 default:

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -75,7 +75,7 @@ class SpotListViewModel: Serviceable {
 extension SpotListViewModel {
     
     func getDong() {
-        let requestQuery = GetDongRequestQuery(latitude: userCoordinate.latitude,
+        let requestQuery = GetDongRequest(latitude: userCoordinate.latitude,
                                                longitude: userCoordinate.longitude)
         
         ACService.shared.spotListService.getDong(

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/Type/ReviewVerificationErrorType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/Type/ReviewVerificationErrorType.swift
@@ -1,0 +1,14 @@
+//
+//  SpotUploadErrorType.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 2/21/25.
+//
+
+import Foundation
+
+enum ReviewVerificationErrorType {
+    
+    case locationAccessFail, unsupportedRegion
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/Type/ReviewVerificationErrorType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/Type/ReviewVerificationErrorType.swift
@@ -9,6 +9,6 @@ import Foundation
 
 enum ReviewVerificationErrorType {
     
-    case locationAccessFail, unsupportedRegion
+    case unknownSpot, unsupportedRegion
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
@@ -153,13 +153,20 @@ private extension SpotSearchViewController {
 
     func bindViewModel() {
         self.spotSearchViewModel.onSuccessGetSearchSuggestion.bind { [weak self] onSuccess in
-            guard let onSuccess, let data = self?.spotSearchViewModel.searchSuggestionData.value else { return }
+            guard let onSuccess else { return }
             if onSuccess {
+                guard let data = self?.spotSearchViewModel.searchSuggestionData.value else { return }
                 self?.spotSearchView.bindData(data)
                 self?.addActionToSearchKeywordButton()
             } else {
+                let errorType = self?.spotSearchViewModel.reviewVerificationErrorType
+                let alertHandler = AlertHandler()
+                if errorType == .unsupportedRegion {
+                    alertHandler.showUnsupportedRegionImageAlert(from: self!)
+                } // TODO: errorType == 존재하지 않는 장소일 때 Alert 필요 (40403 에러)
                 self?.showDefaultAlert(title: "추천 검색어 로드 실패", message: "추천 검색어 로드에 실패했습니다.")
             }
+            self?.spotSearchViewModel.onSuccessGetSearchSuggestion.value = nil
         }
         
         // TODO: - 계속 불러야 해서 일단 데이터 자체 바인딩. 추후 로딩이 필요한 경우 onSuccessGetSearchKeyword으로 바인딩 로직 재구성
@@ -181,8 +188,9 @@ private extension SpotSearchViewController {
         }
         
         self.spotSearchViewModel.onSuccessGetReviewVerification.bind { [weak self] onSuccess in
-            guard let onSuccess, let data = self?.spotSearchViewModel.reviewVerification.value else { return }
+            guard let onSuccess else { return }
             if onSuccess {
+                guard let data = self?.spotSearchViewModel.reviewVerification.value else { return }
                 if data {
                     self?.hasCompletedSelection = true
                     self?.dismiss(animated: true)
@@ -190,10 +198,15 @@ private extension SpotSearchViewController {
                     let alertHandler = AlertHandler()
                     alertHandler.showLocationAccessFailImageAlert(from: self!)
                 }
-                self?.spotSearchViewModel.reviewVerification.value = nil
             } else {
+                let errorType = self?.spotSearchViewModel.reviewVerificationErrorType
+                let alertHandler = AlertHandler()
+                if errorType == .unsupportedRegion {
+                    alertHandler.showUnsupportedRegionImageAlert(from: self!)
+                } // TODO: errorType == 존재하지 않는 장소일 때 Alert 필요 (40403 에러)
                 self?.showDefaultAlert(title: "연관 검색어 로드 실패", message: "연관 검색어 로드에 실패했습니다.")
             }
+            self?.spotSearchViewModel.reviewVerification.value = nil
         }
         
     }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
@@ -25,6 +25,8 @@ class SpotSearchViewModel: Serviceable {
     
     var reviewVerification: ObservablePattern<Bool> = ObservablePattern(nil)
     
+    var reviewVerificationErrorType: ReviewVerificationErrorType? = nil
+    
     init(latitude: Double, longitude: Double) {
         self.latitude = latitude
         self.longitude = longitude
@@ -74,6 +76,14 @@ class SpotSearchViewModel: Serviceable {
                 self?.handleReissue { [weak self] in
                     self?.getSearchSuggestion()
                 }
+            case .requestErr(let error):
+                print("🥑getSearchSuggestion requestErr: \(error)")
+                if error.code == 40403 {
+                    self?.reviewVerificationErrorType = .unknownSpot
+                } else if error.code == 40405 {
+                    self?.reviewVerificationErrorType = .unsupportedRegion
+                }
+                self?.onSuccessGetSearchSuggestion.value = false
             default:
                 print("VM - Fail to getSearchSuggestion")
                 self?.onSuccessGetSearchSuggestion.value = false
@@ -91,6 +101,18 @@ class SpotSearchViewModel: Serviceable {
             case .success(let data):
                 self?.reviewVerification.value = data.success
                 self?.onSuccessGetReviewVerification.value = true
+            case .requestErr(let error):
+                print("🥑get reviewVerification requestErr: \(error)")
+                if error.code == 40403 {
+                    self?.reviewVerificationErrorType = .unknownSpot
+                } else if error.code == 40405 {
+                    self?.reviewVerificationErrorType = .unsupportedRegion
+                }
+                self?.onSuccessGetReviewVerification.value = false
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getReviewVerification(spotId: spotId)
+                }
             default:
                 print("VM - Fail to get review verification")
                 self?.onSuccessGetReviewVerification.value = false


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #76 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
**1. SpotList 뷰**
- 40405(서비스 불가지역) 에러일 때 네비게이션 타이틀, 에러뷰 띄움
- View에 구현했던 errorView를 삭제하고 VC에서 baseErrorView를 사용함 (2가지 에러 뷰가 필요하기 때문)

**2. 리뷰 업로드**
- 40405(서비스 불가지역) 에러일 때 ImageAlert 띄움
  - getSearchSuggestion, getReviewVerification 모두에 적용해둠

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

## 📸 스크린샷
|SpotList|Review|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/618106dd-1025-4fbb-8fdb-94ff7f2899eb" width="250">|<img src = "https://github.com/user-attachments/assets/7ad24ab8-cb8f-49e1-81c7-af3f739d4f60" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #76
