### PR TITLE
[FIX] 2차 QA 준비 및 2차 QA 대응 - 수민 (#78)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -1972,7 +1972,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2009,7 +2009,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
@@ -18,8 +18,11 @@ enum HeaderType {
     }
     
     static func headerWithToken() -> [String: String] {
-        let token = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) ?? ""
-        return ["Content-Type" : "application/json", "Authorization" : "Bearer " + token]
+        if let token = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) {
+            return ["Content-Type" : "application/json", "Authorization" : "Bearer " + token]
+        } else {
+            return basicHeader
+        }
     }
     
     static func tokenOnly() -> [String:String] {

--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseNavViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseNavViewController.swift
@@ -32,6 +32,8 @@ class BaseNavViewController: UIViewController {
     
     let glassMorphismView = GlassmorphismView()
     
+    var backCompletion: (() -> Void)?
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -194,18 +196,21 @@ extension BaseNavViewController {
     
     // MARK: - 뒤로가기 버튼
     
-    func setBackButton() {
+    func setBackButton(completion: (() -> Void)? = nil) {
         setButtonStyle(button: leftButton, image: .leftArrow)
         setButtonAction(button: leftButton, target: self, action: #selector(backButtonTapped))
+        self.backCompletion = completion
     }
     
     @objc
     func backButtonTapped() {
+        backCompletion?()
         if let navigationController = navigationController {
             navigationController.popViewController(animated: true)
         } else {
             dismiss(animated: true)
         }
+        self.backCompletion = nil
     }
     
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -77,7 +77,6 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
         
         self.setBackButton()
         self.setGlassMorphism()
-//        setGlassMorphism()
     }
     
     private func addTarget() {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -116,8 +116,8 @@ extension SpotDetailViewModel {
 extension SpotDetailViewModel {
     
     func redirectToNaverMap() {
+        ACLocationManager.shared.stopUpdatingLocation()
         ACLocationManager.shared.checkUserDeviceLocationServiceAuthorization()
-        ACLocationManager.shared.startUpdatingLocation()
     }
     
 }
@@ -128,6 +128,8 @@ extension SpotDetailViewModel {
 extension SpotDetailViewModel: ACLocationManagerDelegate {
     
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
+        ACLocationManager.shared.stopUpdatingLocation()
+        ACLocationManager.shared.removeDelegate(self)
         guard let appName = Bundle.main.bundleIdentifier else { return }
         let sname = "내 위치"
         let urlString = "nmap://route/walk?slat=\(coordinate.latitude)&slng=\(coordinate.longitude)&sname=\(sname)&dlat=\(spotDetail.value?.latitude ?? 0)&dlng=\(spotDetail.value?.longitude ?? 0)&dname=\(spotDetail.value?.name ?? "")&appname=\(appName)"

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -29,7 +29,7 @@ class SpotDetailViewModel: Serviceable {
     }
     
     deinit {
-       ACLocationManager.shared.removeDelegate(self)
+        ACLocationManager.shared.removeDelegate(self)
     }
 
 }
@@ -116,7 +116,7 @@ extension SpotDetailViewModel {
 extension SpotDetailViewModel {
     
     func redirectToNaverMap() {
-        ACLocationManager.shared.stopUpdatingLocation()
+        ACLocationManager.shared.addDelegate(self)
         ACLocationManager.shared.checkUserDeviceLocationServiceAuthorization()
     }
     
@@ -128,7 +128,6 @@ extension SpotDetailViewModel {
 extension SpotDetailViewModel: ACLocationManagerDelegate {
     
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
-        ACLocationManager.shared.stopUpdatingLocation()
         ACLocationManager.shared.removeDelegate(self)
         guard let appName = Bundle.main.bundleIdentifier else { return }
         let sname = "내 위치"

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -25,11 +25,6 @@ class SpotDetailViewModel: Serviceable {
     
     init(spotID: Int64) {
         self.spotID = spotID
-        ACLocationManager.shared.addDelegate(self)
-    }
-    
-    deinit {
-        ACLocationManager.shared.removeDelegate(self)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -31,15 +31,13 @@ class SpotListViewController: BaseNavViewController {
         bindViewModel()
         setCollectionView()
         addTarget()
-        
-
+        viewModel.requestLocation()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(false)
         
         self.tabBarController?.tabBar.isHidden = false
-        viewModel.requestLocation()
     }
     
     override func setHierarchy() {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #78

## 🥔 **작업 내용**
2차 QA를 위한 배포를 준비하고 제 몫에 해당하는 QA를 대응했습니다.
#### 장소 상세 뷰에서 pop 시 네이버 지도로 가는 에러 
- SpotDetailVM이 deinit되기 전 (deinit 시 ACLocationManager의 Delegate이 제거되는 로직 호출됨), locationManager 메소드가 호출되는 문제
- 해결방법 : ACLocationManager의 델리게이트 적용 / 해제 시점을 변경했습니다.
  - ACLocationManager.shared.addDelegate 호출 시점: init -> redirectToNMAP (길찾기 버튼을 클릭 시 호출되는 메소드)
  - ACLocationManager.shared.removeDelegate 호출 시점: deinit -> locationManager (네이버지도 redirect 메소드)

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #78
