### PR TITLE
[FEAT] 외국 위/경도일 때 동네인증 & 네이버 길찾기 분기처리 (#82)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		74D31C7C2D5BF90300B4B2B4 /* AlbumModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D31C7B2D5BF8FD00B4B2B4 /* AlbumModel.swift */; };
 		74D31C802D5C025900B4B2B4 /* PhotoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D31C7F2D5C025200B4B2B4 /* PhotoCollectionViewCell.swift */; };
 		74D831922D6878A5003384C6 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 74D831912D6878A5003384C6 /* AmplitudeSwift */; };
+		74E38D342D69B46F009449D4 /* LocationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E38D332D69B468009449D4 /* LocationUtils.swift */; };
 		D61917E92D3E4410001BF0EE /* OnboardingTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61917E82D3E4410001BF0EE /* OnboardingTargetType.swift */; };
 		D61917EC2D3E484A001BF0EE /* OnboardingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61917EB2D3E484A001BF0EE /* OnboardingRequest.swift */; };
 		D6232C952D3A294C003FF208 /* AlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6232C942D3A294C003FF208 /* AlertHandler.swift */; };
@@ -460,6 +461,7 @@
 		74D31C792D5841D100B4B2B4 /* PhotoCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewController.swift; sourceTree = "<group>"; };
 		74D31C7B2D5BF8FD00B4B2B4 /* AlbumModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumModel.swift; sourceTree = "<group>"; };
 		74D31C7F2D5C025200B4B2B4 /* PhotoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewCell.swift; sourceTree = "<group>"; };
+		74E38D332D69B468009449D4 /* LocationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUtils.swift; sourceTree = "<group>"; };
 		B28431BAB67B99CD7B85C705 /* Pods_ACON_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ACON_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB785B4E26FA7C11BB85A55D /* Pods-ACON-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ACON-iOS.debug.xcconfig"; path = "Target Support Files/Pods-ACON-iOS/Pods-ACON-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		D61917E82D3E4410001BF0EE /* OnboardingTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTargetType.swift; sourceTree = "<group>"; };
@@ -1158,6 +1160,7 @@
 		748D6F792D2BCCEF007690B4 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				74E38D332D69B468009449D4 /* LocationUtils.swift */,
 				74054ECD2D32549800D1CDE4 /* ACLocationManager.swift */,
 				74054EC92D32533800D1CDE4 /* MultitaskDelegate.swift */,
 				748D6F812D2BCDB0007690B4 /* ScreenUtils.swift */,
@@ -1894,6 +1897,7 @@
 				741E68A22D3D5FA200DF99EF /* ACService.swift in Sources */,
 				D6FF82E92D3805F000090233 /* DislikeCollectionViewType.swift in Sources */,
 				156AA7242D6504F1005B8DCE /* GetVerifiedAreaListResponse.swift in Sources */,
+				74E38D342D69B46F009449D4 /* LocationUtils.swift in Sources */,
 				1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */,
 				D6FF82F72D381C2000090233 /* LongBoxViewCell.swift in Sources */,
 				D6978F542D37B29100523A25 /* OnboardingService.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Extensions/UIViewController+.swift
+++ b/ACON-iOS/ACON-iOS/Global/Extensions/UIViewController+.swift
@@ -24,7 +24,10 @@ extension UIViewController {
     
     // MARK: - 아이폰 기본 확인 Alert 띄우기
     
-    func showDefaultAlert(title: String, message: String, okText: String = StringLiterals.Alert.ok) {
+    func showDefaultAlert(title: String,
+                          message: String,
+                          okText: String = StringLiterals.Alert.ok,
+                          completion: (() -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         // TODO: - 추후 배경색 및 폰트색도 변경
         alert.view.subviews.first?.subviews.first?.subviews.first?.backgroundColor = .gray8
@@ -38,10 +41,13 @@ extension UIViewController {
         alert.setValue(messageString, forKey: "attributedMessage")
             
         
-        let okAction = UIAlertAction(title: okText, style: .default, handler: nil)
+        let okAction = UIAlertAction(title: okText, style: .default) { _ in
+            completion?()
+        }
         alert.addAction(okAction)
         okAction.setValue(UIColor.org2, forKey: "titleTextColor")
-        present(alert, animated: true, completion: nil)
+        
+        present(alert, animated: true)
     }
     
     

--- a/ACON-iOS/ACON-iOS/Global/Utils/LocationUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/LocationUtils.swift
@@ -1,0 +1,29 @@
+//
+//  LocationUtils.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 2/22/25.
+//
+
+struct LocationUtils {
+    
+    static let minLatitude = 33.1
+    
+    static let maxLatitude = 38.6
+    
+    static let minLongitude = 124.6
+    
+    static let maxLongitude = 131.9
+    
+    static func isKorea(_ lat: Double, _ long: Double) -> Bool {
+        if lat > minLatitude
+            && lat < maxLatitude
+            && long > minLongitude
+            && long < maxLongitude {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -81,13 +81,32 @@ class LocalVerificationViewController: BaseNavViewController {
 private extension LocalVerificationViewController {
     
     func bindViewModel() {
-        self.localVerificationViewModel.isLocationChecked.bind { [weak self] isChecked in
-            guard let isChecked else { return }
+        localVerificationViewModel.isLocationChecked.bind { [weak self] isChecked in
+            guard let self = self,
+                  let isChecked else { return }
             if isChecked {
-                self?.pushToLocalMapVC()
+                if localVerificationViewModel.isLocationKorea {
+                    pushToLocalMapVC()
+                } else {
+                    switch localVerificationViewModel.flowType {
+                    case .onboarding:
+                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "온보딩으로 이동", completion: {
+                            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                                sceneDelegate.window?.rootViewController = OnboardingViewController()
+                            }
+                        })
+                    default:
+                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "홈으로 이동", completion: {
+                            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                                sceneDelegate.window?.rootViewController = ACTabBarController()
+                            }
+                        })
+                    }
+                }
             } else {
-                self?.showDefaultAlert(title: "위치 확인 실패", message: "위치를 확인할 수 없습니다.")
+                self.showDefaultAlert(title: "위치 확인 실패", message: "위치를 확인할 수 없습니다.")
             }
+            localVerificationViewModel.isLocationChecked.value = nil
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
@@ -20,6 +20,8 @@ class LocalVerificationViewModel: Serviceable {
     
     var isLocationChecked: ObservablePattern<Bool> = ObservablePattern(nil)
     
+    var isLocationKorea: Bool = true
+    
     var userCoordinate: CLLocationCoordinate2D? = nil
     
     init(flowType: LocalVerificationFlowType) {
@@ -65,8 +67,8 @@ class LocalVerificationViewModel: Serviceable {
 extension LocalVerificationViewModel: ACLocationManagerDelegate {
     
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
-        print("성공 - 위도: \(coordinate.latitude), 경도: \(coordinate.longitude)")
         self.userCoordinate = coordinate
+        self.isLocationKorea = LocationUtils.isKorea(coordinate.latitude, coordinate.longitude)
         isLocationChecked.value = true
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -238,8 +238,8 @@ extension ProfileView {
         let label = UILabel()
         label.setLabel(text: areaName,
                        style: .t2,
-                       color: .org1)
-        
+                       color: .org1,
+                       alignment: .center)
         verifiedAreaBox.setContentView(to: label)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -93,7 +93,7 @@ private extension ProfileViewController {
                   let onSuccess = onSuccess else { return }
             // TODO: onSuccess 분기처리
             // TODO: 인증동네 추후 여러개로 수정(Sprint3)
-            let firstAreaName: String = self.viewModel.userInfo.verifiedAreaList.first?.name ?? "impossible"
+            let firstAreaName: String = self.viewModel.userInfo.verifiedAreaList.first?.name ?? "???"
             if onSuccess {
                 profileView.do {
                     $0.setProfileImage(self.viewModel.userInfo.profileImage)

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -144,6 +144,7 @@ private extension SpotDetailViewController {
     
 }
 
+
 // MARK: - setUI
 
 private extension SpotDetailViewController {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -116,6 +116,12 @@ private extension SpotDetailViewController {
             }
         }
         
+        self.spotDetailViewModel.isLocationKorea.bind { [weak self] isLocationKorea in
+            guard let isLocationKorea else { return }
+            if !isLocationKorea {
+                self?.showDefaultAlert(title: "알림", message: "현재 네이버지도 사용이 불가능한 지역에 있어요.")
+            }
+        }
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -23,6 +23,8 @@ class SpotDetailViewModel: Serviceable {
     
     let onSuccessPostGuidedSpotRequest: ObservablePattern<Bool> = ObservablePattern(nil)
     
+    let isLocationKorea: ObservablePattern<Bool> = ObservablePattern(nil)
+    
     init(spotID: Int64) {
         self.spotID = spotID
     }
@@ -124,18 +126,21 @@ extension SpotDetailViewModel: ACLocationManagerDelegate {
     
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
         ACLocationManager.shared.removeDelegate(self)
-        guard let appName = Bundle.main.bundleIdentifier else { return }
-        let sname = "내 위치"
-        let urlString = "nmap://route/walk?slat=\(coordinate.latitude)&slng=\(coordinate.longitude)&sname=\(sname)&dlat=\(spotDetail.value?.latitude ?? 0)&dlng=\(spotDetail.value?.longitude ?? 0)&dname=\(spotDetail.value?.name ?? "")&appname=\(appName)"
-        guard let encodedStr = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
-        
-        guard let url = URL(string: encodedStr) else { return }
-        guard let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id311867728?mt=8") else { return }
-        
-        if UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url)
-        } else {
-            UIApplication.shared.open(appStoreURL)
+        self.isLocationKorea.value = LocationUtils.isKorea(coordinate.latitude, coordinate.longitude)
+        if isLocationKorea.value == true {
+            guard let appName = Bundle.main.bundleIdentifier else { return }
+            let sname = "내 위치"
+            let urlString = "nmap://route/walk?slat=\(coordinate.latitude)&slng=\(coordinate.longitude)&sname=\(sname)&dlat=\(spotDetail.value?.latitude ?? 0)&dlng=\(spotDetail.value?.longitude ?? 0)&dname=\(spotDetail.value?.name ?? "")&appname=\(appName)"
+            guard let encodedStr = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+            
+            guard let url = URL(string: encodedStr) else { return }
+            guard let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id311867728?mt=8") else { return }
+            
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url)
+            } else {
+                UIApplication.shared.open(appStoreURL)
+            }
         }
     }
     


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #82

## 🥔 **작업 내용**
외국 위/경도일 때 동네인증 화면과 네이버 길찾기를 못 하도록 분기처리하여 알럿으로 막아두었습니다 !

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 14 Pro Max|<img src = "https://github.com/user-attachments/assets/e81856e3-632d-48a2-8c9e-10a8f0cac8dd" width ="250">|

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #82
